### PR TITLE
Py2/Py3 compatibility fixes (relative imports, new->types etc.)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 # command to install dependencies
 install: pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+
+# command to install dependencies
+install: pip install coverage
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+
+# command to run tests
+script: nosetests --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --verbosity=3 test/testall.py

--- a/Xlib/display.py
+++ b/Xlib/display.py
@@ -17,16 +17,16 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 # Python modules
-import new
+import types
 
 # Xlib modules
-import error
-import ext
-import X
+from . import error
+from . import ext
+from . import X
 
 # Xlib.protocol modules
-import protocol.display
-from protocol import request, event, rq
+from . import protocol.display
+from .protocol import request, event, rq
 
 # Xlib.xobjects modules
 import xobject.resource
@@ -78,7 +78,7 @@ class _BaseDisplay(protocol.display.Display):
         return r.atom
 
 
-class Display:
+class Display(object):
     def __init__(self, display = None):
         self.display = _BaseDisplay(display)
 
@@ -126,9 +126,14 @@ class Display:
         # Finalize extensions by creating new classes
         for type, dict in self.class_extension_dicts.items():
             origcls = self.display.resource_classes[type]
-            self.display.resource_classes[type] = new.classobj(origcls.__name__,
-                                                               (origcls,),
-                                                               dict)
+            if hasattr(types, 'ClassType'):
+                self.display.resource_classes[type] = types.ClassType(origcls.__name__,
+                                                                      (origcls,),
+                                                                      dict)
+            else:
+                self.display.resource_classes[type] = types.new_class(origcls.__name__,
+                                                                      (origcls,),
+                                                                      dict)
 
         # Problem: we have already created some objects without the
         # extensions: the screen roots and default colormaps.
@@ -216,7 +221,7 @@ class Display:
     def __getattr__(self, attr):
         try:
             function = self.display_extension_methods[attr]
-            return new.instancemethod(function, self, self.__class__)
+            return types.MethodType(function, self, self.__class__)
         except KeyError:
             raise AttributeError(attr)
 
@@ -277,7 +282,7 @@ class Display:
                 if hasattr(cls, name):
                     raise AssertionError('attempting to replace %s method: %s' % (type, name))
 
-                method = new.instancemethod(function, None, cls)
+                method = types.MethodType(function, None, cls)
 
                 # Maybe should check extension overrides too
                 try:
@@ -297,8 +302,12 @@ class Display:
         extension_event.
         """
 
-        newevt = new.classobj(evt.__name__, evt.__bases__,
-                              evt.__dict__.copy())
+        if hasattr(types, 'ClassType'):
+            newevt = types.ClassType(evt.__name__, evt.__bases__,
+                                     evt.__dict__.copy())
+        else:
+            newevt = types.new_class(evt.__name__, evt.__bases__,
+                                     evt.__dict__.copy())
         newevt._code = code
 
         self.display.add_extension_event(code, newevt)
@@ -321,8 +330,12 @@ class Display:
         extension_event.
         """
 
-        newevt = new.classobj(evt.__name__, evt.__bases__,
-                              evt.__dict__.copy())
+        if hasattr(types, 'ClassType'):
+            newevt = types.ClassType(evt.__name__, evt.__bases__,
+                                     evt.__dict__.copy())
+        else:
+            newevt = types.new_class(evt.__name__, evt.__bases__,
+                                     evt.__dict__.copy())
         newevt._code = code
 
         self.display.add_extension_event(code, newevt, subcode)

--- a/Xlib/error.py
+++ b/Xlib/error.py
@@ -20,10 +20,10 @@
 import string
 
 # Xlib modules
-import X
+from . import X
 
 # Xlib.protocol modules
-from Xlib.protocol import rq
+from .protocol import rq
 
 
 class DisplayError(Exception):
@@ -129,7 +129,7 @@ xerror_class = {
     }
 
 
-class CatchError:
+class CatchError(object):
     def __init__(self, *errors):
         self.error_types = errors
         self.error = None

--- a/Xlib/protocol/display.py
+++ b/Xlib/protocol/display.py
@@ -26,16 +26,16 @@ import errno
 import socket
 
 # Xlib modules
-from Xlib import error
-from Xlib.ext import ge
+from .. import error
+from ..ext import ge
 
-from Xlib.support import lock, connect
+from ..support import lock, connect
 
 # Xlib.protocol modules
-import rq
-import event
+from . import rq
+from . import event
 
-class Display:
+class Display(object):
     resource_classes = {}
     extension_major_opcodes = {}
     error_classes = error.xerror_class.copy()

--- a/Xlib/protocol/event.py
+++ b/Xlib/protocol/event.py
@@ -18,10 +18,10 @@
 
 
 # Xlib modules
-from Xlib import X
+from .. import X
 
 # Xlib.protocol modules
-import rq
+from . import rq
 
 
 class AnyEvent(rq.Event):

--- a/Xlib/protocol/request.py
+++ b/Xlib/protocol/request.py
@@ -18,11 +18,11 @@
 
 
 # Xlib modules
-from Xlib import X
+from .. import X
 
 # Xlib.protocol modules
-import rq
-import structs
+from . import rq
+from . import structs
 
 
 class CreateWindow(rq.Request):

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -24,11 +24,10 @@ import struct
 import string
 from array import array
 import types
-import new
 
 # Xlib modules
-from Xlib import X
-from Xlib.support import lock
+from .. import X
+from ..support import lock
 
 
 class BadDataError(Exception): pass
@@ -52,17 +51,17 @@ struct_to_array_codes = { }
 for c in 'bhil':
     size = array(c).itemsize
 
-    array_unsigned_codes[size] = string.upper(c)
+    array_unsigned_codes[size] = c.upper()
     try:
         struct_to_array_codes[signed_codes[size]] = c
-        struct_to_array_codes[unsigned_codes[size]] = string.upper(c)
+        struct_to_array_codes[unsigned_codes[size]] = c.upper()
     except KeyError:
         pass
 
 # print array_unsigned_codes, struct_to_array_codes
 
 
-class Field:
+class Field(object):
     """Field objects represent the data fields of a Struct.
 
     Field objects must have the following attributes:
@@ -829,7 +828,7 @@ class EventField(ValueField):
 # Struct is also usable.
 #
 
-class ScalarObj:
+class ScalarObj(object):
     def __init__(self, code):
         self.structcode = code
         self.structvalues = 1
@@ -840,7 +839,7 @@ Card8Obj  = ScalarObj('B')
 Card16Obj = ScalarObj('H')
 Card32Obj = ScalarObj('L')
 
-class ResourceObj:
+class ResourceObj(object):
     structcode = 'L'
     structvalues = 1
 
@@ -860,7 +859,7 @@ class ResourceObj:
 WindowObj = ResourceObj('window')
 ColormapObj = ResourceObj('colormap')
 
-class StrClass:
+class StrClass(object):
     structcode = None
 
     def pack_value(self, val):
@@ -873,7 +872,7 @@ class StrClass:
 Str = StrClass()
 
 
-class Struct:
+class Struct(object):
 
     """Struct objects represents a binary data structure.  It can
     contain both fields with static and dynamic sizes.  However, all
@@ -1096,8 +1095,8 @@ class Struct:
         # memory leak isn't that serious.  Besides, Python 2.0 has
         # real garbage collect.
 
-        exec code
-        self.to_binary = new.instancemethod(to_binary, self, self.__class__)
+        exec(code)
+        self.to_binary = types.MethodType(to_binary, self, self.__class__)
 
         # Finally call it manually
         return apply(self.to_binary, varargs, keys)
@@ -1181,8 +1180,8 @@ class Struct:
 
         # Finally, compile function as for to_binary.
 
-        exec code
-        self.parse_value = new.instancemethod(parse_value, self, self.__class__)
+        exec(code)
+        self.parse_value = types.MethodType(parse_value, self, self.__class__)
 
         # Call it manually
         return self.parse_value(val, display, rawdict)
@@ -1285,8 +1284,8 @@ class Struct:
 
         # Finally, compile function as for to_binary.
 
-        exec code
-        self.parse_binary = new.instancemethod(parse_binary, self, self.__class__)
+        exec(code)
+        self.parse_binary = types.MethodType(parse_binary, self, self.__class__)
 
         # Call it manually
         return self.parse_binary(data, display, rawdict)
@@ -1412,7 +1411,7 @@ class DictWrapper(GetAttrData):
             return cmp(self._data, other)
 
 
-class Request:
+class Request(object):
     def __init__(self, display, onerror = None, *args, **keys):
         self._errorhandler = onerror
         self._binary = apply(self._request.to_binary, args, keys)

--- a/Xlib/protocol/structs.py
+++ b/Xlib/protocol/structs.py
@@ -17,10 +17,10 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 # Xlib modules
-from Xlib import X
+from .. import X
 
 # Xlib.protocol modules
-import rq
+from . import rq
 
 def WindowValues(arg):
     return rq.ValueList( arg, 4, 0,

--- a/Xlib/rdb.py
+++ b/Xlib/rdb.py
@@ -28,7 +28,7 @@ import re
 import sys
 
 # Xlib modules
-from support import lock
+from .support import lock
 
 # Set up a few regexpes for parsing string representation of resources
 
@@ -49,7 +49,7 @@ class OptionError(Exception):
     pass
 
 
-class ResourceDB:
+class ResourceDB(object):
     def __init__(self, file = None, string = None, resources = None):
         self.db = {}
         self.lock = lock.allocate_lock()
@@ -189,7 +189,7 @@ class ResourceDB:
 
         self.lock.release()
 
-    def __getitem__(self, (name, cls)):
+    def __getitem__(self, keys_tuple):
         """db[name, class]
 
         Return the value matching the resource identified by NAME and
@@ -197,6 +197,7 @@ class ResourceDB:
         """
 
         # Split name and class into their parts
+        name, cls = keys_tuple
 
         namep = string.split(name, '.')
         clsp = string.split(cls, '.')
@@ -376,7 +377,7 @@ class ResourceDB:
         return argv
 
 
-class _Match:
+class _Match(object):
     def __init__(self, path, dbs):
         self.path = path
 
@@ -551,7 +552,7 @@ def output_escape(value):
 # Option type definitions
 #
 
-class Option:
+class Option(object):
     def __init__(self):
         pass
 

--- a/Xlib/support/lock.py
+++ b/Xlib/support/lock.py
@@ -16,7 +16,7 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-class _DummyLock:
+class _DummyLock(object):
     def __init__(self):
 
         # This might be nerdy, but by assigning methods like this

--- a/Xlib/xauth.py
+++ b/Xlib/xauth.py
@@ -26,7 +26,7 @@ FamilyDECnet = X.FamilyDECnet
 FamilyChaos = X.FamilyChaos
 FamilyLocal = 256
 
-class Xauthority:
+class Xauthority(object):
     def __init__(self, filename = None):
         if filename is None:
             filename = os.environ.get('XAUTHORITY')

--- a/Xlib/xobject/resource.py
+++ b/Xlib/xobject/resource.py
@@ -18,7 +18,7 @@
 
 from Xlib.protocol import request
 
-class Resource:
+class Resource(object):
     def __init__(self, display, rid, owner = 0):
         self.display = display
         self.id = rid

--- a/examples/childwin.py
+++ b/examples/childwin.py
@@ -24,7 +24,7 @@ import sys
 import os
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, display, Xutil
 

--- a/examples/draw-proto.py
+++ b/examples/draw-proto.py
@@ -23,7 +23,7 @@ import sys
 import os
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X
 from Xlib.protocol import display

--- a/examples/draw.py
+++ b/examples/draw.py
@@ -23,7 +23,7 @@ import sys
 import os
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, display, Xutil
 

--- a/examples/get_selection.py
+++ b/examples/get_selection.py
@@ -23,7 +23,7 @@ import sys
 import os
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, display, Xutil, Xatom
 

--- a/examples/profilex.py
+++ b/examples/profilex.py
@@ -7,7 +7,7 @@ import sys
 import os
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, display, Xatom
 

--- a/examples/put_selection.py
+++ b/examples/put_selection.py
@@ -23,7 +23,7 @@ import sys
 import os
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, display, Xutil, Xatom
 from Xlib.protocol import event

--- a/examples/record_demo.py
+++ b/examples/record_demo.py
@@ -25,7 +25,7 @@ import sys
 import os
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, XK, display
 from Xlib.ext import record

--- a/examples/security.py
+++ b/examples/security.py
@@ -24,7 +24,7 @@ import sys, os
 from optparse import OptionParser
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib.display import Display
 from Xlib.ext import security

--- a/examples/shapewin.py
+++ b/examples/shapewin.py
@@ -23,7 +23,7 @@ import sys
 import os
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, display, Xutil
 from Xlib.ext import shape

--- a/examples/xfixes.py
+++ b/examples/xfixes.py
@@ -23,7 +23,7 @@
 import sys, os, time
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib.display import Display
 

--- a/examples/xinerama.py
+++ b/examples/xinerama.py
@@ -22,7 +22,7 @@
 import sys, os, pprint
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, display, Xutil
 from Xlib.ext import xinerama

--- a/examples/xrandr.py
+++ b/examples/xrandr.py
@@ -22,7 +22,7 @@
 import sys, os, pprint
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from Xlib import X, display, Xutil
 from Xlib.ext import randr

--- a/test/gen/genprottest.py
+++ b/test/gen/genprottest.py
@@ -1011,7 +1011,7 @@ void output(char *name, void *data, int length)
 PY_HEADER = r'''#!/usr/bin/env python
 
 import sys, os
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import string
 import unittest

--- a/test/test_events_be.py
+++ b/test/test_events_be.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys, os
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import string
 import unittest

--- a/test/test_events_le.py
+++ b/test/test_events_le.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys, os
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import string
 import unittest

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys, os
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import unittest
 from Xlib.protocol import rq

--- a/test/test_rdb.py
+++ b/test/test_rdb.py
@@ -3,7 +3,7 @@
 import sys
 import os
 
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import Xlib.rdb
 

--- a/test/test_requests_be.py
+++ b/test/test_requests_be.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys, os
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import string
 import unittest

--- a/test/test_requests_le.py
+++ b/test/test_requests_le.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys, os
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import string
 import unittest

--- a/test/testall.py
+++ b/test/testall.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import sys, os
+import string
+import unittest
+import struct
+import array
+
+import coverage
+
+testfolder = os.path.abspath(os.path.dirname(__file__))
+package_root = os.path.abspath(os.path.join(testfolder, ".."))
+sys.path.append(package_root)
+
+# needs to be called before importing the modules
+cov = coverage.coverage(branch = True, omit = os.path.join(package_root, 'examples', '*.py'))
+cov.start()
+
+from Xlib.protocol import request, rq, event
+import Xlib.protocol.event
+
+def is_big_endian():
+    return struct.unpack('BB', struct.pack('H', 0x0100))[0] != 0
+
+def run_tests():
+    if is_big_endian():
+        excludes = ['test_events_le', 'test_requests_le', ]
+    else:
+        excludes = ['test_events_be', 'test_requests_be', ]
+
+    suite = unittest.TestSuite()
+
+    sys.path.append(testfolder)
+
+    for root, dirs, files in os.walk(testfolder):
+        test_modules = [
+            file.replace('.py', '') for file in files if
+                file.startswith('test_') and
+                file.endswith('.py')]
+
+        test_modules = [mod for mod in test_modules if mod.lower() not in excludes]
+        print('test_modules:')
+        print(test_modules)
+        for mod in test_modules:
+
+            imported_mod = __import__(mod, globals(), locals())
+
+            suite.addTests(
+                unittest.defaultTestLoader.loadTestsFromModule(imported_mod))
+
+    unittest.TextTestRunner(verbosity=3).run(suite)
+    cov.stop()
+    #print(cov.analysis())
+    print(cov.report())
+    cov.html_report(
+        directory = os.path.join(package_root, "Coverage_report"),
+        omit = [os.path.join(package_root, 'examples', '*.py'),
+                os.path.join(package_root, 'utils', '*.py'),
+                os.path.join(package_root, 'test', '*.py'), ]
+        )
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/utils/parsexbug.py
+++ b/utils/parsexbug.py
@@ -7,7 +7,7 @@ import struct
 
 
 # Change path so we find Xlib
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 def dummy_buffer(str, x, y = sys.maxint):
     return str[x:y]


### PR DESCRIPTION
I've started massive fixes for Py2/Py3 compatibility. Many imports are made relative. Deprecated module `new` is replaced with the `types` one. There is only one conditional change:

* `types.ClassType` works in Py2
* `types.new_class` works in Py3.3+

Travis CI runs Py3.3/3.4/3.5 tests as well. Py2.6/2.7 are 100% OK, Py3 tests are failing for now. Next steps are to replace many things like `string.split()` functions with method `split()` of the string object.