### PR TITLE
Get rid of string module functions, reduce types module usage

### DIFF
--- a/Xlib/error.py
+++ b/Xlib/error.py
@@ -16,9 +16,6 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-# Standard modules
-import string
-
 # Xlib modules
 from . import X
 
@@ -76,9 +73,9 @@ class XError(rq.GetAttrData, Exception):
         s = []
         for f in ('code', 'resource_id', 'sequence_number',
                   'major_opcode', 'minor_opcode'):
-            s.append('%s = %s' % (f, self._data[f]))
+            s.append('{0} = {1}'.format(f, self._data[f]))
 
-        return '%s: %s' % (self.__class__, string.join(s, ', '))
+        return '{0}: {1}'.format(self.__class__, ', '.join(s))
 
 class XResourceError(XError):
     _fields = rq.Struct( rq.Card8('type'),  # Always 0

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -422,7 +422,7 @@ class String16(ValueField):
 
     def pack_value(self, val):
         """Convert 8-byte string into 16-byte list"""
-        if type(val) is types.StringType:
+        if type(val) is bytes:
             val = map(lambda c: ord(c), val)
 
         slen = len(val)
@@ -643,7 +643,7 @@ class PropertyData(ValueField):
         if fmt not in (8, 16, 32):
             raise BadDataError('Invalid property data format %d' % fmt)
 
-        if type(val) is types.StringType:
+        if type(val) is bytes:
             size = fmt / 8
             vlen = len(val)
             if vlen % size:
@@ -1190,7 +1190,7 @@ class TextElements8(ValueField):
 
         for v in value:
             # Let values be simple strings, meaning a delta of 0
-            if type(v) is types.StringType:
+            if type(v) is bytes:
                 v = (0, v)
 
             # A tuple, it should be (delta, string)

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -421,7 +421,7 @@ class String16(ValueField):
         self.pad = pad
 
     def pack_value(self, val):
-        # Convert 8-byte string into 16-byte list
+        """Convert 8-byte string into 16-byte list"""
         if type(val) is types.StringType:
             val = map(lambda c: ord(c), val)
 
@@ -573,7 +573,7 @@ class Object(ValueField):
         return self.type.pack_value(val)
 
     def check_value(self, val):
-        if type(val) is types.TupleType:
+        if type(val) is tuple:
             vals = []
             i = 0
             for f in self.type.fields:
@@ -589,7 +589,7 @@ class Object(ValueField):
                     i = i + 1
             return vals
 
-        if type(val) is types.DictType:
+        if type(val) is dict:
             data = val
         elif isinstance(val, DictWrapper):
             data = val._data
@@ -655,7 +655,7 @@ class PropertyData(ValueField):
             dlen = vlen / size
 
         else:
-            if type(val) is types.TupleType:
+            if type(val) is tuple:
                 val = list(val)
 
             size = fmt / 8
@@ -1196,10 +1196,10 @@ class TextElements8(ValueField):
             # A tuple, it should be (delta, string)
             # Encode it as one or more textitems
 
-            if type(v) in (types.TupleType, types.DictType) or \
+            if type(v) in (tuple, dict) or \
                isinstance(v, DictWrapper):
 
-                if type(v) is types.TupleType:
+                if type(v) is tuple:
                     delta, str = v
                 else:
                     delta = v['delta']

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -21,7 +21,6 @@
 import sys
 import traceback
 import struct
-import string
 from array import array
 import types
 
@@ -533,7 +532,7 @@ class List(ValueField):
             for v in val:
                 data.append(self.type.pack_value(v))
 
-            data = string.join(data, '')
+            data = ''.join(data)
 
         if self.pad:
             dlen = len(data)
@@ -1391,7 +1390,7 @@ class Event(GetAttrData):
                 val = val | 0x80
             kwlist.append('%s = %s' % (kw, repr(val)))
 
-        kws = string.join(kwlist, ', ')
+        kws = ', '.join(kwlist)
         return '%s(%s)' % (self.__class__, kws)
 
     def __cmp__(self, other):

--- a/Xlib/rdb.py
+++ b/Xlib/rdb.py
@@ -381,7 +381,7 @@ class _Match(object):
     def __init__(self, path, dbs):
         self.path = path
 
-        if type(dbs) is types.TupleType:
+        if type(dbs) is tuple:
             self.skip = 0
             self.group = dbs
 

--- a/Xlib/rdb.py
+++ b/Xlib/rdb.py
@@ -69,7 +69,7 @@ class ResourceDB(object):
 
         """
 
-        if type(file) is types.StringType:
+        if type(file) is bytes:
             file = open(file, 'r')
 
         self.insert_string(file.read())

--- a/Xlib/rdb.py
+++ b/Xlib/rdb.py
@@ -22,8 +22,7 @@
 
 
 # Standard modules
-import string
-import types
+import locale
 import re
 import sys
 
@@ -84,7 +83,7 @@ class ResourceDB(object):
         """
 
         # First split string into lines
-        lines = string.split(data, '\n')
+        lines = data.split('\n')
 
         while lines:
             line = lines[0]
@@ -122,15 +121,15 @@ class ResourceDB(object):
             for i in range(1, len(splits), 2):
                 s = splits[i]
                 if len(s) == 3:
-                    splits[i] = chr(string.atoi(s, 8))
+                    splits[i] = chr(locale.atoi(s, 8))
                 elif s == 'n':
                     splits[i] = '\n'
 
             # strip the last value part to get rid of any
             # unescaped blanks
-            splits[-1] = string.rstrip(splits[-1])
+            splits[-1] = splits[-1].rstrip()
 
-            value = string.join(splits, '')
+            value = ''.join(splits)
 
             self.insert(res, value)
 
@@ -199,8 +198,8 @@ class ResourceDB(object):
         # Split name and class into their parts
         name, cls = keys_tuple
 
-        namep = string.split(name, '.')
-        clsp = string.split(cls, '.')
+        namep = name.split('.')
+        clsp = cls.split('.')
 
         # It is an error for name and class to have different number
         # of parts
@@ -537,7 +536,7 @@ def output_escape(value):
                       ('\000', '\\000'),
                       ('\n', '\\n')):
 
-        value = string.replace(value, char, esc)
+        value = value.replace(char, esc)
 
     # If first or last character is space or tab, escape them.
     if value[0] in ' \t':

--- a/Xlib/support/connect.py
+++ b/Xlib/support/connect.py
@@ -17,7 +17,6 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import sys
-import string
 
 # List the modules which contain the corresponding functions
 
@@ -43,7 +42,7 @@ _default_auth_mod = 'unix_connect'
 # Figure out which OS we're using.
 # sys.platform is either "OS-ARCH" or just "OS".
 
-_parts = string.split(sys.platform, '-')
+_parts = sys.platform.split('-')
 platform = _parts[0]
 del _parts
 

--- a/Xlib/support/unix_connect.py
+++ b/Xlib/support/unix_connect.py
@@ -17,7 +17,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import re
-import string
+import locale
 import os
 import platform
 import socket
@@ -106,8 +106,8 @@ def new_get_auth(sock, dname, host, dno):
 
         # Convert the prettyprinted IP number into 4-octet string.
         # Sometimes these modules are too damn smart...
-        octets = string.split(sock.getpeername()[0], '.')
-        addr = string.join(map(lambda x: chr(int(x)), octets), '')
+        octets = sock.getpeername()[0].split('.')
+        addr = ''.join(map(lambda x: chr(int(x)), octets))
     else:
         family = xauth.FamilyLocal
         addr = socket.gethostname()
@@ -143,9 +143,9 @@ def old_get_auth(sock, dname, host, dno):
         #      DISPLAY SCHEME COOKIE
         # We're interested in the two last parts for the
         # connection establishment
-        lines = string.split(data, '\n')
+        lines = data.split('\n')
         if len(lines) >= 1:
-            parts = string.split(lines[0], None, 2)
+            parts = lines[0].split(None, 2)
             if len(parts) == 3:
                 auth_name = parts[1]
                 hexauth = parts[2]
@@ -153,7 +153,7 @@ def old_get_auth(sock, dname, host, dno):
 
                 # Translate hexcode into binary
                 for i in range(0, len(hexauth), 2):
-                    auth = auth + chr(string.atoi(hexauth[i:i+2], 16))
+                    auth = auth + chr(locale.atoi(hexauth[i:i+2], 16))
 
                 auth_data = auth
     except os.error:

--- a/Xlib/xobject/colormap.py
+++ b/Xlib/xobject/colormap.py
@@ -22,7 +22,7 @@ from Xlib.protocol import request
 import resource
 
 import re
-import string
+import locale
 
 rgb_res = [
     re.compile(r'\Argb:([0-9a-fA-F]{1,4})/([0-9a-fA-F]{1,4})/([0-9a-fA-F]{1,4})\Z'),
@@ -73,13 +73,13 @@ class Colormap(resource.Resource):
             m = r.match(name)
             if m:
                 rs = m.group(1)
-                r = string.atoi(rs + '0' * (4 - len(rs)), 16)
+                r = locale.atoi(rs + '0' * (4 - len(rs)), 16)
 
                 gs = m.group(2)
-                g = string.atoi(gs + '0' * (4 - len(gs)), 16)
+                g = locale.atoi(gs + '0' * (4 - len(gs)), 16)
 
                 bs = m.group(3)
-                b = string.atoi(bs + '0' * (4 - len(bs)), 16)
+                b = locale.atoi(bs + '0' * (4 - len(bs)), 16)
 
                 return self.alloc_color(r, g, b)
 

--- a/Xlib/xobject/drawable.py
+++ b/Xlib/xobject/drawable.py
@@ -16,8 +16,6 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-import string
-
 from Xlib import X, Xatom, Xutil
 from Xlib.protocol import request, rq
 
@@ -668,7 +666,7 @@ class Window(Drawable):
         if d is None or d.format != 8:
             return None
         else:
-            parts = string.split(d.value, '\0')
+            parts = d.value.split('\0')
             if len(parts) < 2:
                 return None
             else:

--- a/test/gen/genprottest.py
+++ b/test/gen/genprottest.py
@@ -97,7 +97,7 @@ def build_request(endian):
             sys.stderr.write('missing def for request: %s\n' % name)
         else:
             vardefs = request_var_defs.get(name, [()])
-            if type(vardefs) is not types.ListType:
+            if type(vardefs) is not list:
                 vardefs = [vardefs]
 
             i = 0
@@ -129,7 +129,7 @@ def build_request(endian):
                 sys.stderr.write('missing def for reply: %s\n' % name)
             else:
                 vardefs = reply_var_defs.get(name, ())
-                if type(vardefs) is not types.ListType:
+                if type(vardefs) is not list:
                     vardefs = [vardefs]
 
                 i = 0
@@ -302,7 +302,7 @@ def build_event(endian):
             sys.stderr.write('missing def for event: %s\n' % name)
         else:
             vardefs = event_var_defs.get(name, [()])
-            if type(vardefs) is not types.ListType:
+            if type(vardefs) is not list:
                 vardefs = [vardefs]
 
             i = 0

--- a/test/gen/genprottest.py
+++ b/test/gen/genprottest.py
@@ -6,7 +6,6 @@ import os
 sys.path.insert(1, os.path.join(sys.path[0], '../..'))
 
 import types
-import string
 import struct
 from whrandom import randint, choice
 
@@ -35,11 +34,11 @@ def read_defs():
     event_defs = {}
 
     for line in sys.stdin.readlines():
-        parts = string.split(string.strip(line))
+        parts = line.strip().split()
 
         fields = []
         for f in parts[2:]:
-            fields.append(string.split(f, ':'))
+            fields.append(f.split(':'))
 
         if parts[0] == 'REQUEST':
             request_defs[parts[1]] = fields
@@ -176,7 +175,7 @@ def build_request(endian):
     reply_bins = {}
     pc = os.popen('./genrequest', 'r')
     for line in pc.readlines():
-        parts = string.split(string.strip(line))
+        parts = line.strip().split()
         if parts[0] == 'REQUEST':
             req_bins[parts[1]] = parts[2]
         elif parts[0] == 'REPLY':
@@ -347,7 +346,7 @@ def build_event(endian):
     evt_bins = {}
     pc = os.popen('./genevent', 'r')
     for line in pc.readlines():
-        parts = string.split(string.strip(line))
+        parts = line.strip().split()
         if parts[0] == 'EVENT':
             evt_bins[parts[1]] = parts[2]
 
@@ -488,7 +487,7 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
                                   'xKeymapEvent'):
                     extra_vars.append('%s %s_def[%d] = { %s };'
                                       % (ctype, f.name, vflen,
-                                         string.join(map(str, vfdata), ', ')))
+                                         ', '.join(map(str, vfdata))))
                     varfs[f.name] = ('memcpy(data.xstruct.map, %s_def, sizeof(%s_def));'
                                      % (f.name, f.name),
                                      vflen, 0)
@@ -497,7 +496,7 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
                              % (ctype, f.name, deflen))
                     extra_vars.append('%s %s_def[%d] = { %s };'
                                       % (ctype, f.name, vflen,
-                                         string.join(map(str, vfdata), ', ')))
+                                         ', '.join(map(str, vfdata))))
                     varfs[f.name] = ('memcpy(data.%s, %s_def, sizeof(%s_def));'
                                      % (f.name, f.name, f.name),
                                      vflen, 0)
@@ -522,7 +521,7 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
 
                 extra_vars.append('struct { xHostEntry e; CARD8 name[4]; } %s_def[%d] = { %s };'
                                   % (f.name, len(pydata),
-                                     string.join(cdata, ', ')))
+                                     ', '.join(cdata)))
 
                 varfs[f.name] = ('memcpy(data.%s, %s_def, sizeof(%s_def));'
                                  % (f.name, f.name, f.name),
@@ -551,13 +550,13 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
                         pyd[f.type.fields[sj].name] = d[sj]
 
                     pydata.append(pyd)
-                    defdata.append('{ ' + string.join(map(str, d), ', ') + ' }')
+                    defdata.append('{ ' + ', '.join(map(str, d)) + ' }')
 
                 fc.write('x%s %s[%d];\n        ' % (vfname, f.name, vflen))
 
                 extra_vars.append('x%s %s_def[%d] = { %s };'
                                   % (vfname, f.name, vflen,
-                                     string.join(defdata, ', ')))
+                                     ', '.join(defdata)))
                 varfs[f.name] = ('memcpy(data.%s, %s_def, sizeof(%s_def));'
                                  % (f.name, f.name, f.name),
                                  vflen, 0)
@@ -623,7 +622,7 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
 
             # vlcode.append('data.%s_flags = %d;' % (f.name, flags))
 
-            varfs[f.name] = (string.join(vlcode, ' '), 0, 0)
+            varfs[f.name] = (' '.join(vlcode), 0, 0)
             args[f.name] = vlargs
 
         #
@@ -679,7 +678,7 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
             fc.write('%s %s[%d];\n      ' % (ctype, f.name, len(cdata)))
             extra_vars.append('%s %s_def[%d] = { %s };'
                               % (ctype, f.name, len(cdata),
-                                 string.join(cdata, ', ')))
+                                 ', '.join(cdata)))
             varfs[f.name] = ('memcpy(data.%s, %s_def, sizeof(%s_def));'
                              % (f.name, f.name, f.name),
                              length, format)
@@ -699,11 +698,11 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
             elif format == 16:
                 ctype = 'CARD16'
                 clen = length + length % 2
-                cdata = string.join(map(str, data), ', ')
+                cdata = ', '.join(map(str, data))
             elif format == 32:
                 ctype = 'CARD32'
                 clen = length
-                cdata = string.join(map(str, data), ', ')
+                cdata = ', '.join(map(str, data))
 
             if not isinstance(f, rq.FixedPropertyData):
                 fc.write('%s %s[%d];\n        ' %
@@ -825,7 +824,7 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
                 pyd[pyf.type.fields[sj].name] = d[sj]
 
             fc.write('{ %s def = { %s };\n      '
-                     % (t, string.join(map(str, d), ', ')))
+                     % (t, ', '.join(map(str, d))))
             fc.write('memcpy(&data.xstruct.%s, &def, sizeof(def)); }\n        ' % f)
             args[pyf.name] = pyd
 
@@ -870,7 +869,7 @@ def pad4(l):
     return l + (4 - l % 4) % 4
 
 def cstring(s):
-    return '"' + string.join(map(lambda c: '\\x%x' % ord(c), s), '') + '"'
+    return '"' + ''.join(map(lambda c: '\\x%x' % ord(c), s)) + '"'
 
 
 def build_args(args):
@@ -878,7 +877,7 @@ def build_args(args):
     for kw, val in args.items():
         kwlist.append("            '%s': %s,\n" % (kw, repr(val)))
 
-    return '{\n' + string.join(kwlist, '') + '            }'
+    return '{\n' + ''.join(kwlist) + '            }'
 
 def build_bin(bin):
     bins = []
@@ -892,7 +891,7 @@ def build_bin(bin):
         except IndexError:
             bins2.append("'%s'" % bins[i])
 
-    return string.join(bins2, ' \\\n            ')
+    return ' \\\n            '.join(bins2)
 
 
 request_var_defs = {
@@ -1013,7 +1012,6 @@ PY_HEADER = r'''#!/usr/bin/env python
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-import string
 import unittest
 from Xlib.protocol import request, rq, event
 import Xlib.protocol.event
@@ -1040,7 +1038,7 @@ class CmpArray:
 rq.array = CmpArray
 
 def tohex(bin):
-    bin = string.join(map(lambda c: '\\x%%02x' %% ord(c), bin), '')
+    bin = ''.join(map(lambda c: '\\x%%02x' %% ord(c), bin))
 
     bins = []
     for i in range(0, len(bin), 16):
@@ -1053,7 +1051,7 @@ def tohex(bin):
         except IndexError:
             bins2.append("'%%s'" %% bins[i])
 
-    return string.join(bins2, ' \\\n            ')
+    return ' \\\n            '.join(bins2)
 
 class DummyDisplay:
     def get_resource_class(self, x):

--- a/test/test_events_be.py
+++ b/test/test_events_be.py
@@ -3,7 +3,6 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-import string
 import unittest
 from Xlib.protocol import request, rq, event
 import Xlib.protocol.event
@@ -30,7 +29,7 @@ class CmpArray:
 rq.array = CmpArray
 
 def tohex(bin):
-    bin = string.join(map(lambda c: '\\x%02x' % ord(c), bin), '')
+    bin = ''.join(map(lambda c: '\\x%02x' % ord(c), bin))
 
     bins = []
     for i in range(0, len(bin), 16):
@@ -43,7 +42,7 @@ def tohex(bin):
         except IndexError:
             bins2.append("'%s'" % bins[i])
 
-    return string.join(bins2, ' \\\n            ')
+    return ' \\\n            '.join(bins2)
 
 class DummyDisplay:
     def get_resource_class(self, x):

--- a/test/test_events_le.py
+++ b/test/test_events_le.py
@@ -3,7 +3,6 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-import string
 import unittest
 from Xlib.protocol import request, rq, event
 import Xlib.protocol.event

--- a/test/test_requests_be.py
+++ b/test/test_requests_be.py
@@ -3,7 +3,6 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-import string
 import unittest
 from Xlib.protocol import request, rq, event
 import Xlib.protocol.event
@@ -30,7 +29,7 @@ class CmpArray:
 rq.array = CmpArray
 
 def tohex(bin):
-    bin = string.join(map(lambda c: '\\x%02x' % ord(c), bin), '')
+    bin = ''.join(map(lambda c: '\\x%02x' % ord(c), bin))
 
     bins = []
     for i in range(0, len(bin), 16):
@@ -43,7 +42,7 @@ def tohex(bin):
         except IndexError:
             bins2.append("'%s'" % bins[i])
 
-    return string.join(bins2, ' \\\n            ')
+    return ' \\\n            '.join(bins2)
 
 class DummyDisplay:
     def get_resource_class(self, x):

--- a/test/test_requests_le.py
+++ b/test/test_requests_le.py
@@ -3,7 +3,6 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-import string
 import unittest
 from Xlib.protocol import request, rq, event
 import Xlib.protocol.event
@@ -30,7 +29,7 @@ class CmpArray:
 rq.array = CmpArray
 
 def tohex(bin):
-    bin = string.join(map(lambda c: '\\x%02x' % ord(c), bin), '')
+    bin = ''.join(map(lambda c: '\\x%02x' % ord(c), bin))
 
     bins = []
     for i in range(0, len(bin), 16):
@@ -43,7 +42,7 @@ def tohex(bin):
         except IndexError:
             bins2.append("'%s'" % bins[i])
 
-    return string.join(bins2, ' \\\n            ')
+    return ' \\\n            '.join(bins2)
 
 class DummyDisplay:
     def get_resource_class(self, x):


### PR DESCRIPTION
This adds +4 tests passed on Py3.
Next step would be unicode/str/bytes clarification for both Pythons using `from __future__ import unicode_literals` (seems the most annoying thing).