### PR TITLE
Fix a lot of Python 3 issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/python-xlib/python-xlib.svg?branch=master)](https://travis-ci.org/python-xlib/python-xlib)
 [![codecov.io](https://codecov.io/github/python-xlib/python-xlib/coverage.svg?branch=master)](https://codecov.io/github/python-xlib/python-xlib?branch=master)
+[![Code Health](https://landscape.io/github/python-xlib/python-xlib/master/landscape.svg?style=flat)](https://landscape.io/github/python-xlib/python-xlib/master)
 
 # The Python X Library
 

--- a/Xlib/protocol/request.py
+++ b/Xlib/protocol/request.py
@@ -784,7 +784,7 @@ class ListFontsWithInfo(rq.ReplyRequest):
 
     def __init__(self, *args, **keys):
         self._fonts = []
-        apply(ReplyRequest.__init__, (self, ) + args, keys)
+        rq.ReplyRequest.__init__(self, *args, **keys)
 
     def _parse_response(self, data):
 

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -1216,7 +1216,7 @@ class TextElements8(ValueField):
             # Else an integer, i.e. a font change
             else:
                 # Use fontable cast function if instance
-                if type(v) is types.InstanceType:
+                if isinstance(v, Fontable):
                     v = v.__fontable__()
 
                 data = data + struct.pack('>BL', 255, v)

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -390,7 +390,7 @@ class String8(ValueField):
         slen = len(val)
 
         if self.pad:
-            return val + '\0' * ((4 - slen % 4) % 4), slen, None
+            return val + b'\0' * ((4 - slen % 4) % 4), slen, None
         else:
             return val, slen, None
 
@@ -421,9 +421,9 @@ class String16(ValueField):
         slen = len(val)
 
         if self.pad:
-            pad = '\0\0' * (slen % 2)
+            pad = b'\0\0' * (slen % 2)
         else:
-            pad = ''
+            pad = b''
 
         return struct.pack(*('>' + 'H' * slen, ) + tuple(val)) + pad, slen, None
 
@@ -526,11 +526,11 @@ class List(ValueField):
             for v in val:
                 data.append(self.type.pack_value(v))
 
-            data = ''.join(data)
+            data = b''.join(data)
 
         if self.pad:
             dlen = len(data)
-            data = data + '\0' * ((4 - dlen % 4) % 4)
+            data = data + b'\0' * ((4 - dlen % 4) % 4)
 
         return data, len(val), None
 
@@ -641,9 +641,9 @@ class PropertyData(ValueField):
             vlen = len(val)
             if vlen % size:
                 vlen = vlen - vlen % size
-                data = val[:vlen]
+                data = val[:vlen].encode()
             else:
-                data = val
+                data = val.encode()
 
             dlen = vlen // size
 
@@ -656,7 +656,7 @@ class PropertyData(ValueField):
             dlen = len(val)
 
         dl = len(data)
-        data = data + '\0' * ((4 - dl % 4) % 4)
+        data = data + b'\0' * ((4 - dl % 4) % 4)
 
         return data, dlen, fmt
 
@@ -699,7 +699,7 @@ class ValueList(Field):
 
     def pack_value(self, arg, keys):
         mask = 0
-        data = ''
+        data = b''
 
         if arg == self.default:
             arg = keys
@@ -713,7 +713,7 @@ class ValueList(Field):
                     val = field.check_value(val)
 
                 d = struct.pack('=' + field.structcode, val)
-                data = data + d + '\0' * (4 - len(d))
+                data = data + d + b'\0' * (4 - len(d))
 
         return struct.pack(self.maskcode, mask) + data, None, None
 
@@ -1174,7 +1174,7 @@ class TextElements8(ValueField):
                               String8('string', pad = 0) )
 
     def pack_value(self, value):
-        data = ''
+        data = b''
         args = {}
 
         for v in value:
@@ -1213,7 +1213,7 @@ class TextElements8(ValueField):
 
         # Pad out to four byte length
         dlen = len(data)
-        return data + '\0' * ((4 - dlen % 4) % 4), None, None
+        return data + b'\0' * ((4 - dlen % 4) % 4), None, None
 
     def parse_binary_value(self, data, display, length, format):
         values = []

--- a/Xlib/rdb.py
+++ b/Xlib/rdb.py
@@ -460,7 +460,7 @@ def bin_insert(list, element):
     upper = len(list) - 1
 
     while lower <= upper:
-        center = (lower + upper) / 2
+        center = (lower + upper) // 2
         if element < list[center]:
             upper = center - 1
         elif element > list[center]:

--- a/Xlib/rdb.py
+++ b/Xlib/rdb.py
@@ -22,7 +22,6 @@
 
 
 # Standard modules
-import locale
 import re
 import sys
 
@@ -121,7 +120,7 @@ class ResourceDB(object):
             for i in range(1, len(splits), 2):
                 s = splits[i]
                 if len(s) == 3:
-                    splits[i] = chr(locale.atoi(s, 8))
+                    splits[i] = chr(int(s, 8))
                 elif s == 'n':
                     splits[i] = '\n'
 

--- a/Xlib/support/unix_connect.py
+++ b/Xlib/support/unix_connect.py
@@ -17,7 +17,6 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import re
-import locale
 import os
 import platform
 import socket
@@ -153,7 +152,7 @@ def old_get_auth(sock, dname, host, dno):
 
                 # Translate hexcode into binary
                 for i in range(0, len(hexauth), 2):
-                    auth = auth + chr(locale.atoi(hexauth[i:i+2], 16))
+                    auth = auth + chr(int(hexauth[i:i+2], 16))
 
                 auth_data = auth
     except os.error:

--- a/Xlib/xobject/colormap.py
+++ b/Xlib/xobject/colormap.py
@@ -22,7 +22,6 @@ from Xlib.protocol import request
 import resource
 
 import re
-import locale
 
 rgb_res = [
     re.compile(r'\Argb:([0-9a-fA-F]{1,4})/([0-9a-fA-F]{1,4})/([0-9a-fA-F]{1,4})\Z'),
@@ -73,13 +72,13 @@ class Colormap(resource.Resource):
             m = r.match(name)
             if m:
                 rs = m.group(1)
-                r = locale.atoi(rs + '0' * (4 - len(rs)), 16)
+                r = int(rs + '0' * (4 - len(rs)), 16)
 
                 gs = m.group(2)
-                g = locale.atoi(gs + '0' * (4 - len(gs)), 16)
+                g = int(gs + '0' * (4 - len(gs)), 16)
 
                 bs = m.group(3)
-                b = locale.atoi(bs + '0' * (4 - len(bs)), 16)
+                b = int(bs + '0' * (4 - len(bs)), 16)
 
                 return self.alloc_color(r, g, b)
 

--- a/Xlib/xobject/drawable.py
+++ b/Xlib/xobject/drawable.py
@@ -233,7 +233,7 @@ class Drawable(resource.Resource):
 
         maxlen = (self.display.info.max_request_length << 2) \
                  - request.PutImage._request.static_size
-        split = maxlen / stride
+        split = maxlen // stride
 
         x1 = 0
         x2 = width
@@ -459,7 +459,7 @@ class Window(Drawable):
             val = prop.value
             if prop.bytes_after:
                 prop = self.get_property(property, type, sizehint,
-                                         prop.bytes_after / 4 + 1)
+                                         prop.bytes_after // 4 + 1)
                 val = val + prop.value
 
             prop.value = val
@@ -763,7 +763,7 @@ class Window(Drawable):
     # Returns a DictWrapper, or None
 
     def _get_struct_prop(self, pname, ptype, pstruct):
-        r = self.get_property(pname, ptype, 0, pstruct.static_size / 4)
+        r = self.get_property(pname, ptype, 0, pstruct.static_size // 4)
         if r and r.format == 32:
             value = r.value.tostring()
             if len(value) == pstruct.static_size:
@@ -782,7 +782,7 @@ class Window(Drawable):
         else:
             keys.update(hints)
 
-        value = apply(pstruct.to_binary, (), keys)
+        value = pstruct.to_binary(*(), **keys)
 
         self.change_property(pname, ptype, 32, value, onerror = onerror)
 

--- a/examples/childwin.py
+++ b/examples/childwin.py
@@ -54,10 +54,10 @@ class Window:
 
 		bggc.change(foreground=self.screen.white_pixel)
 
-		bgpm.arc(bggc, -bgsize / 2, 0, bgsize, bgsize, 0, 360 * 64)
-		bgpm.arc(bggc, bgsize / 2, 0, bgsize, bgsize, 0, 360 * 64)
-		bgpm.arc(bggc, 0, -bgsize / 2, bgsize, bgsize, 0, 360 * 64)
-		bgpm.arc(bggc, 0, bgsize / 2, bgsize, bgsize, 0, 360 * 64)
+		bgpm.arc(bggc, -bgsize // 2, 0, bgsize, bgsize, 0, 360 * 64)
+		bgpm.arc(bggc, bgsize // 2, 0, bgsize, bgsize, 0, 360 * 64)
+		bgpm.arc(bggc, 0, -bgsize // 2, bgsize, bgsize, 0, 360 * 64)
+		bgpm.arc(bggc, 0, bgsize // 2, bgsize, bgsize, 0, 360 * 64)
 
 		# Actual window
 		self.window = self.screen.root.create_window(
@@ -129,8 +129,8 @@ class Window:
 				if e.detail == 1:
 					print "Moving child window."
 					self.childWindow.configure(
-						x=e.event_x - self.childWidth / 2,
-						y=e.event_y - self.childHeight / 2
+						x=e.event_x - self.childWidth // 2,
+						y=e.event_y - self.childHeight // 2
 						)
 					self.d.flush()
 

--- a/examples/shapewin.py
+++ b/examples/shapewin.py
@@ -59,10 +59,10 @@ class Window:
 
         bggc.change(foreground = self.screen.white_pixel)
 
-        bgpm.arc(bggc, -bgsize / 2, 0, bgsize, bgsize, 0, 360 * 64)
-        bgpm.arc(bggc, bgsize / 2, 0, bgsize, bgsize, 0, 360 * 64)
-        bgpm.arc(bggc, 0, -bgsize / 2, bgsize, bgsize, 0, 360 * 64)
-        bgpm.arc(bggc, 0, bgsize / 2, bgsize, bgsize, 0, 360 * 64)
+        bgpm.arc(bggc, -bgsize // 2, 0, bgsize, bgsize, 0, 360 * 64)
+        bgpm.arc(bggc, bgsize // 2, 0, bgsize, bgsize, 0, 360 * 64)
+        bgpm.arc(bggc, 0, -bgsize // 2, bgsize, bgsize, 0, 360 * 64)
+        bgpm.arc(bggc, 0, bgsize // 2, bgsize, bgsize, 0, 360 * 64)
 
         # Actual window
         self.window = self.screen.root.create_window(
@@ -112,10 +112,10 @@ class Window:
         self.sub_pm.fill_rectangle(gc, 0, 0, self.sub_size, self.sub_size)
         gc.change(foreground = 1)
         self.sub_pm.fill_poly(gc, X.Convex, X.CoordModeOrigin,
-                              [(self.sub_size / 2, 0),
-                               (self.sub_size, self.sub_size / 2),
-                               (self.sub_size / 2, self.sub_size),
-                               (0, self.sub_size / 2)])
+                              [(self.sub_size // 2, 0),
+                               (self.sub_size, self.sub_size // 2),
+                               (self.sub_size // 2, self.sub_size),
+                               (0, self.sub_size // 2)])
         gc.free()
 
         # Set initial mask
@@ -151,14 +151,14 @@ class Window:
                 if e.detail == 1:
                     self.window.shape_mask(shape.ShapeUnion,
                                            shape.ShapeBounding,
-                                           e.event_x - self.add_size / 2,
-                                           e.event_y - self.add_size / 2,
+                                           e.event_x - self.add_size // 2,
+                                           e.event_y - self.add_size // 2,
                                            self.add_pm)
                 elif e.detail == 3:
                     self.window.shape_mask(shape.ShapeSubtract,
                                            shape.ShapeBounding,
-                                           e.event_x - self.sub_size / 2,
-                                           e.event_y - self.sub_size / 2,
+                                           e.event_x - self.sub_size // 2,
+                                           e.event_y - self.sub_size // 2,
                                            self.sub_pm)
 
             # Shape has changed

--- a/test/gen/genprottest.py
+++ b/test/gen/genprottest.py
@@ -232,7 +232,7 @@ def build_request(endian):
         for i in range(0, reqs + 1):
             fpy.write('''
     def testPackRequest%(n)d(self):
-        bin = apply(request.%(req)s._request.to_binary, (), self.req_args_%(n)d)
+        bin = request.%(req)s._request.to_binary(*(), **self.req_args_%(n)d)
         self.assert_(bin == self.req_bin_%(n)d, tohex(bin))
 
     def testUnpackRequest%(n)d(self):
@@ -244,7 +244,7 @@ def build_request(endian):
         for i in range(0, replies + 1):
             fpy.write('''
     def testPackReply%(n)d(self):
-        bin = apply(request.%(req)s._reply.to_binary, (), self.reply_args_%(n)d)
+        bin = request.%(req)s._reply.to_binary(*(), **self.reply_args_%(n)d)
         self.assert_(bin == self.reply_bin_%(n)d, tohex(bin))
 
     def testUnpackReply%(n)d(self):
@@ -394,7 +394,7 @@ def build_event(endian):
         for i in range(0, evts + 1):
             fpy.write('''
     def testPack%(n)d(self):
-        bin = apply(event.%(evt)s._fields.to_binary, (), self.evt_args_%(n)d)
+        bin = event.%(evt)s._fields.to_binary(*(), **self.evt_args_%(n)d)
         self.assert_(bin == self.evt_bin_%(n)d, tohex(bin))
 
     def testUnpack%(n)d(self):
@@ -790,14 +790,14 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
             assert f == 'length'
 
             fc.write('      assert(sizeof(data) % 4 == 0);\n')
-            fc.write('      data.xstruct.length = sizeof(data) / 4;\n')
+            fc.write('      data.xstruct.length = sizeof(data) // 4;\n')
 
         elif isinstance(pyf, rq.ReplyLength):
             assert f == 'length'
 
             fc.write('      assert(sizeof(data) % 4 == 0);\n')
             fc.write('      assert(sizeof(data) >= 32);\n')
-            fc.write('      data.xstruct.length = (sizeof(data) - 32) / 4;\n')
+            fc.write('      data.xstruct.length = (sizeof(data) - 32) // 4;\n')
 
         elif isinstance(pyf, rq.LengthOf):
             fc.write('      data.xstruct.%s = %d;\n' % (f, varfs[pyf.name][1]))
@@ -1021,7 +1021,7 @@ import array
 
 class CmpArray:
     def __init__(self, *args, **kws):
-        self.array = apply(array.array, args, kws)
+        self.array = array.array(*args, **kws)
 
     def __len__(self):
         return len(self.array)

--- a/test/gen/genprottest.py
+++ b/test/gen/genprottest.py
@@ -1019,15 +1019,20 @@ import Xlib.protocol.event
 import struct
 import array
 
-class CmpArray:
+class CmpArray(object):
     def __init__(self, *args, **kws):
         self.array = array.array(*args, **kws)
 
     def __len__(self):
         return len(self.array)
 
-    def __getslice__(self, x, y):
-        return list(self.array[x:y])
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            x = key.start
+            y = key.stop
+            return list(self.array[x:y])
+        else:
+            return self.array[key]
 
     def __getattr__(self, attr):
         return getattr(self.array, attr)

--- a/test/test_events_be.py
+++ b/test/test_events_be.py
@@ -10,15 +10,20 @@ import Xlib.protocol.event
 import struct
 import array
 
-class CmpArray:
+class CmpArray(object):
     def __init__(self, *args, **kws):
         self.array = array.array(*args, **kws)
 
     def __len__(self):
         return len(self.array)
 
-    def __getslice__(self, x, y):
-        return list(self.array[x:y])
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            x = key.start
+            y = key.stop
+            return list(self.array[x:y])
+        else:
+            return self.array[key]
 
     def __getattr__(self, attr):
         return getattr(self.array, attr)

--- a/test/test_events_le.py
+++ b/test/test_events_le.py
@@ -19,15 +19,20 @@ else:
         """Integer representation of a byte indexed from a byte string - Py2"""
         return ord(c)
 
-class CmpArray:
+class CmpArray(object):
     def __init__(self, *args, **kws):
         self.array = array.array(*args, **kws)
 
     def __len__(self):
         return len(self.array)
 
-    def __getslice__(self, x, y):
-        return list(self.array[x:y])
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            x = key.start
+            y = key.stop
+            return list(self.array[x:y])
+        else:
+            return self.array[key]
 
     def __getattr__(self, attr):
         return getattr(self.array, attr)

--- a/test/test_requests_be.py
+++ b/test/test_requests_be.py
@@ -10,15 +10,20 @@ import Xlib.protocol.event
 import struct
 import array
 
-class CmpArray:
+class CmpArray(object):
     def __init__(self, *args, **kws):
         self.array = array.array(*args, **kws)
 
     def __len__(self):
         return len(self.array)
 
-    def __getslice__(self, x, y):
-        return list(self.array[x:y])
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            x = key.start
+            y = key.stop
+            return list(self.array[x:y])
+        else:
+            return self.array[key]
 
     def __getattr__(self, attr):
         return getattr(self.array, attr)

--- a/test/test_requests_le.py
+++ b/test/test_requests_le.py
@@ -10,15 +10,20 @@ import Xlib.protocol.event
 import struct
 import array
 
-class CmpArray:
+class CmpArray(object):
     def __init__(self, *args, **kws):
         self.array = array.array(*args, **kws)
 
     def __len__(self):
         return len(self.array)
 
-    def __getslice__(self, x, y):
-        return list(self.array[x:y])
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            x = key.start
+            y = key.stop
+            return list(self.array[x:y])
+        else:
+            return self.array[key]
 
     def __getattr__(self, attr):
         return getattr(self.array, attr)

--- a/utils/parsexbug.py
+++ b/utils/parsexbug.py
@@ -65,38 +65,42 @@ class ParseString:
         self.get_data = datafunc
         self.data = ''
 
-    def __getitem__(self, i):
-        if i < 0:
-            raise ValueError('bad string index: %d' % i)
+    def __getitem__(self, key):
+        if not isinstance(key, slice):
+            if key < 0:
+                raise ValueError('bad string index: {0}'.format(key))
 
-        if len(self.data) <= i:
-            if not self.get_data:
-                raise RuntimeError('attempt to allocate more data after returning a new ParseString')
+            if len(self.data) <= key:
+                if not self.get_data:
+                    raise RuntimeError('attempt to allocate more data after returning a new ParseString')
 
-            self.data = self.data + self.get_data(i - len(self.data) + 1)
+                self.data = self.data + self.get_data(key - len(self.data) + 1)
 
-        return self.data[i]
+            return self.data[key]
 
-    def __getslice__(self, i, j):
-        if j == sys.maxint:
-            if self.get_data:
-                ps = ParseString(self.get_data)
-                self.get_data = None
-                return ps
-            else:
-                raise RuntimeError('attempt to allocate another ParseString')
+        else:
+            # replacement of __getslice__
+            i = key.start
+            j = key.stop
+            if j == sys.maxint:
+                if self.get_data:
+                    ps = ParseString(self.get_data)
+                    self.get_data = None
+                    return ps
+                else:
+                    raise RuntimeError('attempt to allocate another ParseString')
 
 
-        if i < 0 or j < 0 or i > j:
-            raise ValueError('bad slice indices: [%d:%d]' % (i, j))
+            if i < 0 or j < 0 or i > j:
+                raise ValueError('bad slice indices: [%d:%d]' % (i, j))
 
-        if len(self.data) < j:
-            if not self.get_data:
-                raise RuntimeError('attempt to allocate more data after returning a new ParseString')
+            if len(self.data) < j:
+                if not self.get_data:
+                    raise RuntimeError('attempt to allocate more data after returning a new ParseString')
 
-            self.data = self.data + self.get_data(j - len(self.data))
+                self.data = self.data + self.get_data(j - len(self.data))
 
-        return self.data[i:j]
+            return self.data[i:j]
 
 class DummyDisplay:
     def get_resource_class(self, name):


### PR DESCRIPTION
The fixes reduce Py3 test failures from `(failures=40, errors=207)` to `(failures=47, errors=11)`.

* `apply()` is finally removed
* integer division `/` is replaced with `//`
* `pack_value()` methods use `bytes` almost everywhere
* `atoi()` is replaced with `int()`
* `ord()` is called for Python 2 only (because `bytes` element is already an integer in Py3)
* direct `str()` usage for `bytes` is reduced because `str(b'bytes')` leads to `"b'bytes'"`, not `"bytes"`