### PR TITLE
Make run_examples.py run the scripts with proper interpreter

### DIFF
--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -33,7 +33,8 @@ examples_folder = os.path.abspath(os.path.dirname(__file__)) + "/"
 
 def run_example(path):
     """ Returns returncode of example """
-    proc = subprocess.Popen(path, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = "{} {}".format(sys.executable, path)
+    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     res = proc.communicate()
     if proc.returncode:
         print(res[1].decode())

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -33,7 +33,7 @@ examples_folder = os.path.abspath(os.path.dirname(__file__)) + "/"
 
 def run_example(path):
     """ Returns returncode of example """
-    cmd = "{} {}".format(sys.executable, path)
+    cmd = "{0} {1}".format(sys.executable, path)
     proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     res = proc.communicate()
     if proc.returncode:


### PR DESCRIPTION
I had a little trouble running nosetests locally.

If `/usr/bin/env python` is configured to be e.g. `/usr/bin/python3.4`, then `run_examples.py` will run its subprocess scripts using python3.4 even though `run_examples.py` was run using python2.7.

This pull request fixes this issue by prepending `sys.executable` to the subprocess command.

Before:
```
$ python2.7 examples/run_examples.py

# ^ Crashes for me because my /usr/bin/env python is python3.4 and the
# python3.4 interpreter tries to execute Python2 scripts (e.g. get_selection.py)
```
After:
```
$ python2.7 examples/run_examples.py
....
----------------------------------------------------------------------
Ran 4 tests in 10.839s

OK
```