### PR TITLE
protocol: fix handling of generic events

### DIFF
--- a/Xlib/protocol/display.py
+++ b/Xlib/protocol/display.py
@@ -651,8 +651,10 @@ class Display(object):
 
                 if rtype == 1:
                     gotreq = self.parse_request_response(request) or gotreq
+                    continue
                 elif rtype & 0x7f == ge.GenericEventCode:
                     self.parse_event_response(rtype)
+                    continue
                 else:
                     raise AssertionError(rtype)
 


### PR DESCRIPTION
Make sure we start a new iteration of the parse_response loop upon handling a response, so the code does not try to parse left over received data based on the previous request type.