### PR TITLE
support/vms_connect: fix invalid Python 3 syntax

### DIFF
--- a/Xlib/support/vms_connect.py
+++ b/Xlib/support/vms_connect.py
@@ -60,7 +60,7 @@ def get_socket(dname, host, dno):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((host, 6000 + dno))
 
-    except socket.error, val:
+    except socket.error as val:
         raise error.DisplayConnectionError(dname, str(val))
 
     return s


### PR DESCRIPTION
Fix an error that comes up when byte-compiling the code during install:
```
byte-compiling build/bdist.linux-x86_64/egg/Xlib/support/vms_connect.py to vms_connect.cpython-35.pyc
  File "build/bdist.linux-x86_64/egg/Xlib/support/vms_connect.py", line 63
    except socket.error, val:
                       ^
SyntaxError: invalid syntax

```