### PR TITLE
travis: fix command to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
 
 # command to run tests
 script: 
-  nosetests --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --verbosity=3 test/ examples/run_examples.py
+  nosetests --exe --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --verbosity=3 test/ examples/run_examples.py
 
 after_success:
   - codecov


### PR DESCRIPTION
Make sure nosetest pick up all our tests in test/, including those present in executable files.

Before:
```
nose.selector: INFO: /home/travis/build/benoit-pierre/python-xlib/test/test_events_be.py is executable; skipped
nose.selector: INFO: /home/travis/build/benoit-pierre/python-xlib/test/test_events_le.py is executable; skipped
nose.selector: INFO: /home/travis/build/benoit-pierre/python-xlib/test/test_manual.py is executable; skipped
nose.selector: INFO: /home/travis/build/benoit-pierre/python-xlib/test/test_rdb.py is executable; skipped
nose.selector: INFO: /home/travis/build/benoit-pierre/python-xlib/test/test_requests_le.py is executable; skipped
[...]
Ran 44 tests in 15.906s
```

After:
```
Ran 459 tests in 13.435s
```