### PR TITLE
add GitHub and PyPi deployments to Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,27 @@ script:
 
 after_success:
   - codecov
+
+before_deploy:
+  # Generate source distribution.
+  # Note: only do this with Python 3.5 so we get support for tar.xz, and
+  # because the contents of the distribution are the same for all versions.
+  - case "$TRAVIS_PYTHON_VERSION" in 3.5) python setup.py sdist --formats=xztar;; esac
+  # Generate egg distribution.
+  - python setup.py bdist_egg
+  # Generate wheel distribution.
+  # Note: only do this once for each major Python version, as the minor version
+  # number is not encoded in the resulting filename (and contents are the same).
+  - case "$TRAVIS_PYTHON_VERSION" in 2.7|3.5) python setup.py bdist_wheel;; esac
+
+deploy:
+  - provider: releases
+    api_key:
+      secure: "lBEbXUeBQyDspP0XBGM/NgfzO2AhW3sMRqCKvOxWQNw4VrC+nfXCkF3OyuRkqQbw+25TKHJadjg+NxX/FtCxdKAJo2MeRrCxNmLqVhq3PnRyBSkVROxYfDFZFL12hmeFA0CrZp45uuSWdruU7a0xh9SkFVBdHSYt55jIzbHKZBdqy1fnL/ot+hnafmsUWc+EiP0s6BgLeqihfevxq87imKyzMKpyH8ofwKKWx6LTgq9khJdQt5x4LUm+Kq8HDcdDeJtz2eLFziDGA7ds+aIpbrk0bG8tmT4SaM06EmJCZoegifGWWnkf5xEe5CVmQXS8Xl3R2bgeII5O4eXUWUXk1tT2nuPLPPv4iTSsZkEd1UH/eHupIID/IKuVqo2GrhvzLBcIzDCFaZg/U8ufARmsx1FGfuzqWwzpqXb+tvDBp6Xz6xSpjrUwwJ41oDRWnDzGLN3uvH06VeMcy6pVFftRLbiMVpOEd76tNvGEEEj4ropb7VyvRL+IHGwbb0Ns62toJYDbgzHyBhisN43tFmaT8fpqLvZP7yuRCMIqs8mtH9Iw4YpOJUG8scsFtX445C4xEGw1j/E6TZkjBrfG0O1FVP1Q6wHYCyutCNjvGKnWvyd+4pg1Nzx/HC/O+ioNefVm+jOTjKtKla/kY6P3ctDWGjXgHGqRe6gn0MtwmR/T+mY="
+    file_glob: true
+    file:
+    - dist/*.tar.*
+    - dist/*.egg
+    - dist/*.whl
+    on:
+      tags: true


### PR DESCRIPTION
Will automatically deploy to GitHub/PyPi when a new tag is pushed to master.

Credentials need to be filled-in:
- for GitHub, a new access token must be created (in GitHub settings / Personal access tokens) and encrypted with Travis CLI tool: `travis encrypt`
- similarly, the user/password field must be filled for PyPi (with again the password encrypted with `travis encrypt`)

Note: make sure the (clear text version of the) PyPi password does not contain a `%`, or it will trigger an exception and leak the password in the logs!