### PR TITLE
protocol/display: fix handling of KeymapNotify events

### DIFF
--- a/Xlib/protocol/display.py
+++ b/Xlib/protocol/display.py
@@ -801,7 +801,10 @@ class Display(object):
         # Decrement it by one, so that we don't remove the request
         # that generated these events, if there is such a one.
         # Bug reported by Ilpo Nyyssönen
-        self.get_waiting_request((e.sequence_number - 1) % 65536)
+        # Note: not all events have a sequence_number field!
+        # (e.g. KeymapNotify).
+        if hasattr(e, 'sequence_number'):
+            self.get_waiting_request((e.sequence_number - 1) % 65536)
 
         # print 'recv Event:', e
 

--- a/Xlib/protocol/display.py
+++ b/Xlib/protocol/display.py
@@ -1,4 +1,4 @@
-# -*- coding: iso-8859-1 -*-
+# -*- coding: utf-8 -*-
 #
 # Xlib.protocol.display -- core display communication
 #
@@ -800,7 +800,7 @@ class Display(object):
 
         # Decrement it by one, so that we don't remove the request
         # that generated these events, if there is such a one.
-        # Bug reported by Ilpo Nyyss�nen
+        # Bug reported by Ilpo Nyyssönen
         self.get_waiting_request((e.sequence_number - 1) % 65536)
 
         # print 'recv Event:', e


### PR DESCRIPTION
Don't try to access `sequence_number` member for those events, since they [don't have one](https://github.com/python-xlib/python-xlib/blob/master/Xlib/protocol/event.py#L393).