### PR TITLE
travis: change source distribution format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ after_success:
 
 before_deploy:
   # Generate source distribution.
-  # Note: only do this with Python 3.5 so we get support for tar.xz, and
-  # because the contents of the distribution are the same for all versions.
-  - case "$TRAVIS_PYTHON_VERSION" in 3.5) python setup.py sdist --formats=xztar;; esac
+  # Note: only do this with Python 3.5 because the contents
+  # of the distribution are the same for all versions.
+  - case "$TRAVIS_PYTHON_VERSION" in 3.5) python setup.py sdist --formats=bztar;; esac
   # Generate egg distribution.
   - python setup.py bdist_egg
   # Generate wheel distribution.


### PR DESCRIPTION
Switch to tar.bz2 as tar.xz is not supported by PyPI.