### PR TITLE
CompositeGetOverlayWindow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IntelliJ
+
+.idea/
+

--- a/Xlib/ext/composite.py
+++ b/Xlib/ext/composite.py
@@ -206,7 +206,7 @@ def name_window_pixmap(self):
     cls = self.display.get_resource_class('pixmap', drawable.Pixmap)
     return cls(self.display, pid, owner = 1)
 
-class CompositeGetOverlayWindow(rq.ReplyRequest):
+class GetOverlayWindow(rq.ReplyRequest):
     _request = rq.Struct(
         rq.Card8('opcode'),
         rq.Opcode(7),
@@ -226,7 +226,7 @@ def get_overlay_window(self):
     """Return the overlay window of the root window.
     """
 
-    return CompositeGetOverlayWindow(display = self.display,
+    return GetOverlayWindow(display = self.display,
                               opcode = self.display.get_extension_major(extname),
                               window = self)
 

--- a/Xlib/ext/composite.py
+++ b/Xlib/ext/composite.py
@@ -206,6 +206,29 @@ def name_window_pixmap(self):
     cls = self.display.get_resource_class('pixmap', drawable.Pixmap)
     return cls(self.display, pid, owner = 1)
 
+class CompositeGetOverlayWindow(rq.ReplyRequest):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(7),
+        rq.RequestLength(),
+        rq.Window('window')
+    )
+    _reply = rq.Struct(
+        rq.ReplyCode(),
+        rq.Pad(1),
+        rq.Card16('sequence_number'),
+        rq.ReplyLength(),
+        rq.Window('overlay_window'),
+        rq.Pad(20),
+    )
+
+def get_overlay_window(self):
+    """Return the overlay window of the root window.
+    """
+
+    return CompositeGetOverlayWindow(display = self.display,
+                              opcode = self.display.get_extension_major(extname),
+                              window = self)
 
 def init(disp, info):
     disp.extension_add_method('display',
@@ -235,3 +258,7 @@ def init(disp, info):
     disp.extension_add_method('window',
                               'composite_name_window_pixmap',
                               name_window_pixmap)
+
+    disp.extension_add_method('window',
+                              'composite_get_overlay_window',
+                              get_overlay_window)


### PR DESCRIPTION
I added this function to get the overlay window.

The release function is missing since I'm not sure about how to implement it and I don't need it anyway since I'll be probably switching to C++ to do what I'm doing.

If you can, please check that I implemented it correctly (the protocol fields are 100% accurate, just not sure about the python code since there's some magic going on and I basically looked around and copy-pasted from other methods like a monkey).