### PR TITLE
Fix XRECORD extension and demo

### DIFF
--- a/Xlib/ext/record.py
+++ b/Xlib/ext/record.py
@@ -76,7 +76,7 @@ class RawField(rq.ValueField):
         return val, len(val), None
 
     def parse_binary_value(self, data, display, length, format):
-        return str(data), ''
+        return data, ''
 
 
 class GetVersion(rq.ReplyRequest):

--- a/examples/record_demo.py
+++ b/examples/record_demo.py
@@ -56,7 +56,7 @@ def record_callback(reply):
     if reply.client_swapped:
         print("* received swapped protocol data, cowardly ignored")
         return
-    if not len(reply.data) or ord(reply.data[0]) < 2:
+    if not len(reply.data) or reply.data[0] < 2:
         # not an event
         return
 


### PR DESCRIPTION
Fixes the following traceback when running under Python 3.5

Confirmed it's still working under Python 2.7

```
[osboxes@osboxes QMouseKeys]$ python record_demo.py
RECORD extension version 1.13
Traceback (most recent call last):
  File "record_demo.py", line 105, in <module>
    record_dpy.record_enable_context(ctx, record_callback)
  File "/usr/lib/python3.5/site-packages/Xlib/ext/record.py", line 243, in enable_context
    context = context)
  File "/usr/lib/python3.5/site-packages/Xlib/ext/record.py", line 220, in __init__
    rq.ReplyRequest.__init__(self, *args, **keys)
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/rq.py", line 1361, in __init__
    self.reply()
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/rq.py", line 1373, in reply
    self._display.send_and_recv(request = self._serial)
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/display.py", line 576, in send_and_recv
    gotreq = self.parse_response(request)
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/display.py", line 668, in parse_response
    gotreq = self.parse_request_response(request) or gotreq
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/display.py", line 756, in parse_request_response
    req._parse_response(self.data_recv[:self.recv_packet_len])
  File "/usr/lib/python3.5/site-packages/Xlib/ext/record.py", line 224, in _parse_response
    self._callback(r)
  File "record_demo.py", line 50, in record_callback
    if not len(reply.data) or reply.data[0] < 2:
TypeError: unorderable types: str() < int()
```