### PR TITLE
Fix properties handling

### DIFF
--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -27,7 +27,7 @@ from array import array
 import types
 
 # Python 2/3 compatibility.
-from six import byte2int, indexbytes, iterbytes, string_types
+from six import binary_type, byte2int, indexbytes, iterbytes
 
 # Xlib modules
 from .. import X
@@ -650,7 +650,7 @@ class PropertyData(ValueField):
             ret = None
 
         elif format == 8:
-            ret = (8, data[:length].decode())
+            ret = (8, data[:length])
             data = data[length + ((4 - length % 4) % 4):]
 
         elif format == 16:
@@ -669,8 +669,7 @@ class PropertyData(ValueField):
         if fmt not in (8, 16, 32):
             raise BadDataError('Invalid property data format {0}'.format(fmt))
 
-        if isinstance(val, string_types):
-            val = val.encode()
+        if isinstance(val, binary_type):
             size = fmt // 8
             vlen = len(val)
             if vlen % size:

--- a/Xlib/xobject/drawable.py
+++ b/Xlib/xobject/drawable.py
@@ -421,8 +421,7 @@ class Window(Drawable):
         return request.QueryTree(display = self.display,
                                  window = self.id)
 
-
-    def change_property(self, property, type, format, data,
+    def change_property(self, property, property_type, format, data,
                         mode = X.PropModeReplace, onerror = None):
 
         request.ChangeProperty(display = self.display,
@@ -430,7 +429,7 @@ class Window(Drawable):
                                mode = mode,
                                window = self.id,
                                property = property,
-                               type = type,
+                               type = property_type,
                                data = (format, data))
 
     def delete_property(self, property, onerror = None):
@@ -439,12 +438,12 @@ class Window(Drawable):
                                window = self.id,
                                property = property)
 
-    def get_property(self, property, type, offset, length, delete = 0):
+    def get_property(self, property, property_type, offset, length, delete = 0):
         r = request.GetProperty(display = self.display,
                                 delete = delete,
                                 window = self.id,
                                 property = property,
-                                type = type,
+                                type = property_type,
                                 long_offset = offset,
                                 long_length = length)
 
@@ -456,12 +455,12 @@ class Window(Drawable):
         else:
             return None
 
-    def get_full_property(self, property, type, sizehint = 10):
-        prop = self.get_property(property, type, 0, sizehint)
+    def get_full_property(self, property, property_type, sizehint = 10):
+        prop = self.get_property(property, property_type, 0, sizehint)
         if prop:
             val = prop.value
             if prop.bytes_after:
-                prop = self.get_property(property, type, sizehint,
+                prop = self.get_property(property, property_type, sizehint,
                                          prop.bytes_after // 4 + 1)
                 val = val + prop.value
 

--- a/Xlib/xobject/drawable.py
+++ b/Xlib/xobject/drawable.py
@@ -320,6 +320,9 @@ class Drawable(resource.Resource):
 class Window(Drawable):
     __window__ = resource.Resource.__resource__
 
+    _STRING_ENCODING = 'ISO-8859-1'
+    _UTF8_STRING_ENCODING = 'UTF-8'
+
     def create_window(self, x, y, width, height, border_width, depth,
                       window_class =  X.CopyFromParent,
                       visual = X.CopyFromParent,
@@ -432,6 +435,16 @@ class Window(Drawable):
                                type = property_type,
                                data = (format, data))
 
+    def change_text_property(self, property, property_type, data,
+                        mode = X.PropModeReplace, onerror = None):
+        if not isinstance(data, bytes):
+            if property_type == Xatom.STRING:
+                data = data.encode(self._STRING_ENCODING)
+            elif property_type == self.display.get_atom('UTF8_STRING'):
+                data = data.encode(self._UTF8_STRING_ENCODING)
+        self.change_property(property, property_type, 8, data,
+                             mode=mode, onerror=onerror)
+
     def delete_property(self, property, onerror = None):
         request.DeleteProperty(display = self.display,
                                onerror = onerror,
@@ -468,6 +481,19 @@ class Window(Drawable):
             return prop
         else:
             return None
+
+    def get_full_text_property(self, property, property_type=X.AnyPropertyType, sizehint = 10):
+        prop = self.get_full_property(property, property_type,
+                                      sizehint=sizehint)
+        if prop is None or prop.format != 8:
+            return None
+        if prop.property_type == Xatom.STRING:
+            prop.value = prop.value.decode(self._STRING_ENCODING)
+        elif prop.property_type == self.display.get_atom('UTF8_STRING'):
+            prop.value = prop.value.decode(self._UTF8_STRING_ENCODING)
+        # FIXME: at least basic support for compound text would be nice.
+        # elif prop.property_type == self.display.get_atom('COMPOUND_TEXT'):
+        return prop.value
 
     def list_properties(self):
         r = request.ListProperties(display = self.display,
@@ -636,43 +662,33 @@ class Window(Drawable):
                                  properties = properties)
 
     def set_wm_name(self, name, onerror = None):
-        self.change_property(Xatom.WM_NAME, Xatom.STRING, 8, name,
-                             onerror = onerror)
+        self.change_text_property(Xatom.WM_NAME, Xatom.STRING, name,
+                                  onerror = onerror)
 
     def get_wm_name(self):
-        d = self.get_full_property(Xatom.WM_NAME, Xatom.STRING)
-        if d is None or d.format != 8:
-            return None
-        else:
-            return d.value
+        return self.get_full_text_property(Xatom.WM_NAME, Xatom.STRING)
 
     def set_wm_icon_name(self, name, onerror = None):
-        self.change_property(Xatom.WM_ICON_NAME, Xatom.STRING, 8, name,
-                             onerror = onerror)
+        self.change_text_property(Xatom.WM_ICON_NAME, Xatom.STRING, name,
+                                  onerror = onerror)
 
     def get_wm_icon_name(self):
-        d = self.get_full_property(Xatom.WM_ICON_NAME, Xatom.STRING)
-        if d is None or d.format != 8:
-            return None
-        else:
-            return d.value
-
+        return self.get_full_text_property(Xatom.WM_ICON_NAME, Xatom.STRING)
 
     def set_wm_class(self, inst, cls, onerror = None):
-        self.change_property(Xatom.WM_CLASS, Xatom.STRING, 8,
-                             '%s\0%s\0' % (inst, cls),
-                             onerror = onerror)
+        self.change_text_property(Xatom.WM_CLASS, Xatom.STRING,
+                                  '%s\0%s\0' % (inst, cls),
+                                  onerror = onerror)
 
     def get_wm_class(self):
-        d = self.get_full_property(Xatom.WM_CLASS, Xatom.STRING)
-        if d is None or d.format != 8:
+        value = self.get_full_text_property(Xatom.WM_CLASS, Xatom.STRING)
+        if value is None:
+            return None
+        parts = value.split('\0')
+        if len(parts) < 2:
             return None
         else:
-            parts = d.value.split('\0')
-            if len(parts) < 2:
-                return None
-            else:
-                return parts[0], parts[1]
+            return parts[0], parts[1]
 
     def set_wm_transient_for(self, window, onerror = None):
         self.change_property(Xatom.WM_TRANSIENT_FOR, Xatom.WINDOW,
@@ -718,15 +734,11 @@ class Window(Drawable):
 
 
     def set_wm_client_machine(self, name, onerror = None):
-        self.change_property(Xatom.WM_CLIENT_MACHINE, Xatom.STRING, 8, name,
-                             onerror = onerror)
+        self.change_text_property(Xatom.WM_CLIENT_MACHINE, Xatom.STRING, name,
+                                  onerror = onerror)
 
     def get_wm_client_machine(self):
-        d = self.get_full_property(Xatom.WM_CLIENT_MACHINE, Xatom.STRING)
-        if d is None or d.format != 8:
-            return None
-        else:
-            return d.value
+        return self.get_full_text_property(Xatom.WM_CLIENT_MACHINE, Xatom.STRING)
 
     def set_wm_normal_hints(self, hints = {}, onerror = None, **keys):
         self._set_struct_prop(Xatom.WM_NORMAL_HINTS, Xatom.WM_SIZE_HINTS,

--- a/examples/get_selection.py
+++ b/examples/get_selection.py
@@ -22,6 +22,7 @@
 #    Suite 330,
 #    Boston, MA 02111-1307 USA
 
+import binascii
 import sys
 import os
 
@@ -155,7 +156,13 @@ def output_data(d, r, target_name):
         len(r.value))
 
     if r.format == 8:
-        sys.stdout.write(r.value)
+        if r.property_type == Xatom.STRING:
+            value = r.value.decode('ISO-8859-1')
+        elif r.property_type == d.get_atom('UTF8_STRING'):
+            value = r.value.decode('UTF-8')
+        else:
+            value = binascii.hexlify(r.value).decode('ascii')
+        sys.stdout.write(value)
 
     elif r.format == 32 and r.property_type == Xatom.ATOM:
         for v in r.value:

--- a/test/gen/genprottest.py
+++ b/test/gen/genprottest.py
@@ -908,9 +908,9 @@ def build_bin(bin):
 
 request_var_defs = {
     'InternAtom': ('fuzzy_prop', ),
-    'ChangeProperty': [((8, ''), ),
-                       ((8, 'foo'), ),
-                       ((8, 'zoom'), ),
+    'ChangeProperty': [((8, b''), ),
+                       ((8, b'foo'), ),
+                       ((8, b'zoom'), ),
                        ((16, []), ),
                        ((16, [1, 2, 3]), ),
                        ((16, [1, 2, 3, 4]), ),
@@ -951,9 +951,9 @@ request_var_defs = {
 reply_var_defs = {
     'QueryTree': (7, ),
     'GetAtomName': ('WM_CLASS', ),
-    'GetProperty': [((8, ''), ),
-                       ((8, 'foo'), ),
-                       ((8, 'zoom'), ),
+    'GetProperty': [((8, b''), ),
+                       ((8, b'foo'), ),
+                       ((8, b'zoom'), ),
                        ((16, []), ),
                        ((16, [1, 2, 3]), ),
                        ((16, [1, 2, 3, 4]), ),
@@ -980,7 +980,7 @@ reply_var_defs = {
     }
 
 event_var_defs = {
-    'ClientMessage': [((8, '01234567890123456789'), ),
+    'ClientMessage': [((8, b'01234567890123456789'), ),
                       ((16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), ),
                       ((32, [1, 2, 3, 4, 5]), ) ],
     }

--- a/test/gen/genprottest.py
+++ b/test/gen/genprottest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys
 import os
@@ -74,8 +74,8 @@ def build_request(endian):
 
     fc.write(C_HEADER)
 
-    reqlist = request.major_codes.items()
-    reqlist.sort(lambda x, y: cmp(x[0], y[0]))
+    reqlist = list(request.major_codes.items())
+    reqlist.sort(key=lambda x: x[0])
 
     genfuncs = []
     req_args = {}
@@ -185,7 +185,7 @@ def build_request(endian):
             reply_bins[parts[1]] = parts[2]
 
     fpy = open('../test_requests_%s.py' % endian, 'w')
-    os.chmod('../test_requests_%s.py' % endian, 0755)
+    os.chmod('../test_requests_%s.py' % endian, 0o755)
 
     if endian == 'be':
         e = 'BigEndian'
@@ -268,8 +268,8 @@ def build_event(endian):
 
     fc.write(C_HEADER)
 
-    evtlist = event.event_class.items()
-    evtlist.sort(lambda x, y: cmp(x[0], y[0]))
+    evtlist = list(event.event_class.items())
+    evtlist.sort(key=lambda x: x[0])
 
     genfuncs = []
     evt_args = {}
@@ -353,7 +353,7 @@ def build_event(endian):
             evt_bins[parts[1]] = parts[2]
 
     fpy = open('../test_events_%s.py' % endian, 'w')
-    os.chmod('../test_events_%s.py' % endian, 0755)
+    os.chmod('../test_events_%s.py' % endian, 0o755)
 
     if endian == 'be':
         e = 'BigEndian'
@@ -478,7 +478,7 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
                 def rand(x, rmin = rmin, rmax = rmax):
                     return randint(rmin, rmax)
 
-                vfdata = map(rand, range(0, vflen))
+                vfdata = list(map(rand, range(0, vflen)))
 
                 #
                 # Special case for a few in-line coded lists
@@ -631,11 +631,11 @@ def gen_func(fc, funcname, structname, outputname, pydef, cdef, vardefs):
         #
         elif isinstance(f, rq.TextElements8):
             if isinstance(f, rq.TextElements16):
-                vfstr = '\x02\x02\x10\x23\x00\x12\xff\x01\x02\x03\x04'
+                vfstr = b'\x02\x02\x10\x23\x00\x12\xff\x01\x02\x03\x04'
                 ret = [{'delta': 2, 'string': (0x1023, 0x0012)},
                        0x01020304]
             else:
-                vfstr = '\x03\x02zoo\xff\x01\x02\x03\x04\x02\x00ie'
+                vfstr = b'\x03\x02zoo\xff\x01\x02\x03\x04\x02\x00ie'
                 ret = [{'delta': 2, 'string': 'zoo'},
                        0x01020304,
                        { 'delta': 0, 'string': 'ie'}]
@@ -870,14 +870,16 @@ def pad4(l):
     return l + (4 - l % 4) % 4
 
 def cstring(s):
-    return '"' + ''.join(map(lambda c: '\\x%x' % ord(c), s)) + '"'
+    if not isinstance(s, bytes):
+        s = s.encode('ascii')
+    return '"' + ''.join('\\x%x' % c for c in s) + '"'
 
 
 def build_args(args):
     kwlist = []
     for kw, val in sorted(args.items(), key=lambda i: i[0]):
         if isinstance(val, rq.Event):
-            members = val._data.keys()
+            members = list(val._data.keys())
             members.remove('send_event')
             kwlist.append("            '%s': event.%s(%s),\n" % (
                 kw, val.__class__.__name__,

--- a/test/test_events_be.py
+++ b/test/test_events_be.py
@@ -726,7 +726,7 @@ class TestClientMessage(EndianTest):
     def setUp(self):
         self.evt_args_0 = {
             'sequence_number': 48712,
-            'data': (8, '01234567890123456789'),
+            'data': (8, b'01234567890123456789'),
             'type': 245,
             'client_type': 1340394836,
             'window': 1256861040,

--- a/test/test_events_le.py
+++ b/test/test_events_le.py
@@ -546,7 +546,7 @@ class TestClientMessage(EndianTest):
     def setUp(self):
         self.evt_args_0 = {
             'client_type': 1554224294,
-            'data': (8, '01234567890123456789'),
+            'data': (8, b'01234567890123456789'),
             'sequence_number': 44540,
             'type': 140,
             'window': 610247893,

--- a/test/test_requests_be.py
+++ b/test/test_requests_be.py
@@ -682,7 +682,7 @@ class TestChangeProperty(EndianTest):
     def setUp(self):
         self.req_args_0 = {
             'mode': 0,
-            'data': (8, ''),
+            'data': (8, b''),
             'property': 2085394193,
             'window': 266197951,
             'type': 1343008022,
@@ -693,7 +693,7 @@ class TestChangeProperty(EndianTest):
 
         self.req_args_1 = {
             'mode': 2,
-            'data': (8, 'foo'),
+            'data': (8, b'foo'),
             'property': 449719979,
             'window': 1522118044,
             'type': 121096013,
@@ -705,7 +705,7 @@ class TestChangeProperty(EndianTest):
 
         self.req_args_2 = {
             'mode': 2,
-            'data': (8, 'zoom'),
+            'data': (8, b'zoom'),
             'property': 1009841498,
             'window': 286324270,
             'type': 1547457396,
@@ -964,7 +964,7 @@ class TestGetProperty(EndianTest):
             '\x5d\x30\x8c\xce' '\x50\x42\x12\x95'
 
         self.reply_args_0 = {
-            'value': (8, ''),
+            'value': (8, b''),
             'sequence_number': 30606,
             'property_type': 1392423916,
             'bytes_after': 2046056935,
@@ -975,7 +975,7 @@ class TestGetProperty(EndianTest):
             '\x00\x00\x00\x00' '\x00\x00\x00\x00'
 
         self.reply_args_1 = {
-            'value': (8, 'foo'),
+            'value': (8, b'foo'),
             'sequence_number': 44279,
             'property_type': 186441230,
             'bytes_after': 469299413,
@@ -987,7 +987,7 @@ class TestGetProperty(EndianTest):
             '\x66\x6f\x6f\x00'
 
         self.reply_args_2 = {
-            'value': (8, 'zoom'),
+            'value': (8, b'zoom'),
             'sequence_number': 12674,
             'property_type': 1802804296,
             'bytes_after': 1968158856,

--- a/test/test_requests_le.py
+++ b/test/test_requests_le.py
@@ -483,7 +483,7 @@ class TestGetAtomName(EndianTest):
 class TestChangeProperty(EndianTest):
     def setUp(self):
         self.req_args_0 = {
-            'data': (8, ''),
+            'data': (8, b''),
             'mode': 1,
             'property': 933688309,
             'type': 974400040,
@@ -494,7 +494,7 @@ class TestChangeProperty(EndianTest):
             b'\x08\x00\x00\x00' b'\x00\x00\x00\x00'
 
         self.req_args_1 = {
-            'data': (8, 'foo'),
+            'data': (8, b'foo'),
             'mode': 2,
             'property': 565671953,
             'type': 1075033221,
@@ -506,7 +506,7 @@ class TestChangeProperty(EndianTest):
             b'\x66\x6f\x6f\x00'
 
         self.req_args_2 = {
-            'data': (8, 'zoom'),
+            'data': (8, b'zoom'),
             'mode': 0,
             'property': 1869432878,
             'type': 640951286,
@@ -688,7 +688,7 @@ class TestGetProperty(EndianTest):
             'bytes_after': 1567532733,
             'property_type': 1158159724,
             'sequence_number': 14082,
-            'value': (8, ''),
+            'value': (8, b''),
             }
         self.reply_bin_0 = b'\x01\x08\x02\x37' b'\x00\x00\x00\x00' \
             b'\x6c\x1d\x08\x45' b'\xbd\xa6\x6e\x5d' \
@@ -699,7 +699,7 @@ class TestGetProperty(EndianTest):
             'bytes_after': 2137067287,
             'property_type': 669450745,
             'sequence_number': 13387,
-            'value': (8, 'foo'),
+            'value': (8, b'foo'),
             }
         self.reply_bin_1 = b'\x01\x08\x4b\x34' b'\x01\x00\x00\x00' \
             b'\xf9\x01\xe7\x27' b'\x17\x0f\x61\x7f' \
@@ -711,7 +711,7 @@ class TestGetProperty(EndianTest):
             'bytes_after': 1111517270,
             'property_type': 940849590,
             'sequence_number': 42680,
-            'value': (8, 'zoom'),
+            'value': (8, b'zoom'),
             }
         self.reply_bin_2 = b'\x01\x08\xb8\xa6' b'\x01\x00\x00\x00' \
             b'\xb6\x39\x14\x38' b'\x56\x68\x40\x42' \


### PR DESCRIPTION
With the support for Python 3 we started automatically encoding/decoding 8-bits string properties. This is a mistake, as some properties are binary, and those that are actual text may use different encodings. This PR revert the change: bytes are expected on input and returned on output.

FWIU, there are 3 types of text properties:
* `STRING` for ISO-8859-1 encoded strings
* `UTF8_STRING` for UTF-8 encoded strings
* and `COMPOUND_TEXT` for [ISO/IEC 2022](https://en.wikipedia.org/wiki/ISO/IEC_2022) encoded strings

This PR add 2 convenience helpers for dealing with text properties: `change_text_property` and `get_full_text_property`, with automatic encoding/decoding for `STRING` and `UTF8_STRING`.

Those are automatically used for setting/getting `wm_name`, `wm_icon_name`, `wm_class` and `wm_client_machine`.

Additionally I fixed `examples/get_selection.py` encoding handling.

This fix #48.