### PR TITLE
xinput: implemented XIChangeHierarchy

### DIFF
--- a/Xlib/ext/xinput.py
+++ b/Xlib/ext/xinput.py
@@ -752,8 +752,9 @@ class ChangeHierarchyContext(object):
     def detach_slave(self, deviceid):
         self.events.append((DetachSlave, deviceid))
 
-    def __exit__(self, *exc):
-        _change_hierarchy(self.display, *self.events)
+    def __exit__(self, *exc_info):
+        if exc_info == (None, None, None):
+            _change_hierarchy(self.display, *self.events)
 
 
 def init(disp, info):

--- a/Xlib/ext/xinput.py
+++ b/Xlib/ext/xinput.py
@@ -645,7 +645,7 @@ AddMasterInfo = rq.Struct(
     rq.LengthOf('name', 2),
     rq.Card8('send_core', 1),
     rq.Card8('enable', 1),
-    rq.String8('name', pad=2)
+    rq.String8('name')
 )
 
 RemoveMasterInfo = rq.Struct(

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -417,10 +417,7 @@ class String8(ValueField):
             val_bytes = val.encode()
         slen = len(val_bytes)
 
-        if self.pad == 2:
-            # explicitly add termination character
-            return val_bytes + b'\0' + b'\0' * ((4 - (slen + 1) % 4) % 4), slen, None
-        elif self.pad:
+        if self.pad:
             return val_bytes + b'\0' * ((4 - slen % 4) % 4), slen, None
         else:
             return val_bytes, slen, None

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -417,7 +417,10 @@ class String8(ValueField):
             val_bytes = val.encode()
         slen = len(val_bytes)
 
-        if self.pad:
+        if self.pad == 2:
+            # explicitly add termination character
+            return val_bytes + b'\0' + b'\0' * ((4 - (slen + 1) % 4) % 4), slen, None
+        elif self.pad:
             return val_bytes + b'\0' * ((4 - slen % 4) % 4), slen, None
         else:
             return val_bytes, slen, None


### PR DESCRIPTION
Hi,

First of all, thanks very much for this library and all the work you have invested in this project!

I'm getting more into xinput at the moment and I saw that the implementation of this extension isn't complete in python-xlib. I saw the chance to start contributing and so I implemented xlib's [XIChangeHierarchy](https://www.x.org/releases/X11R7.5/doc/man/man3/XIChangeHierarchy.3.html) function in xinput.py ;)

New functions:

``` python
dpy.xinput_add_master(name, send_core=True, enable=True)
dpy.xinput_remove_master(deviceid, return_mode=2, return_pointer=0, return_keyboard=0)
dpy.xinput_attach_slave(deviceid, new_master)
dpy.xinput_detach_slave(deviceid)
```

It's also possible to send multiple changes in a single request:

``` python
from Xlib.ext.xinput import ChangeHierarchyContext

with ChangeHierarchyContext(dpy) as c:
    c.add_master(...)
    c.remove_master(...)
    c.attach_slave(...)
    c.detach_slave(...)
```

You can use the `xinput` command line tool to see the device hierarchy and verify changes made by the above functions.

Unfortunately, I had to modify `rq.String8` because of an issue with the X Server expecting an zero-terminated string for `AddMaster`. The padding implementation didn't insert a termination character when entering a string that doesn't need padding (e.g. "test") which caused the X Server to crash. I made a minimal change (`pad=2`) to fix that. This change doesn't affect existing code, but I'm not sure if this problem can also occur with other functions. 

Ok, that's it. What do you think?
