### PR TITLE
protocol/display: fix interrupted select handling for Python 3.3/3.4

### DIFF
--- a/Xlib/protocol/display.py
+++ b/Xlib/protocol/display.py
@@ -533,8 +533,12 @@ class Display(object):
             # Ignore errors caused by a signal recieved while blocking.
             # All other errors are re-raised.
             except select.error as err:
-                if err[0] != errno.EINTR:
-                    raise err
+                if isinstance(err, OSError):
+                    code = err.errno
+                else:
+                    code = err[0]
+                if code != errno.EINTR:
+                    raise
 
                 # We must lock send_and_recv before we can loop to
                 # the start of the loop


### PR DESCRIPTION
With Python >=3.3, `select.error` is now an instance of OSError.

Note that there was no issue with Python 3.5 as interrupted system calls are automatically retried.

The logic was tested with this small test script: https://gist.github.com/anonymous/3b366a4dd564c6c82a5bbf03fab50a76