### PR TITLE
protocol/display: fix Python 3 buffer abstraction

### DIFF
--- a/test/test_bytesview.py
+++ b/test/test_bytesview.py
@@ -1,0 +1,27 @@
+
+import unittest
+
+# Python 2/3 compatibility.
+from six import indexbytes, text_type
+
+from Xlib.protocol.display import bytesview
+
+
+class BytesViewTest(unittest.TestCase):
+
+    def test(self):
+        with self.assertRaises(TypeError):
+            bytesview(text_type('foobar'))
+        data = b'0123456789ABCDEF'
+        view = bytesview(data)
+        self.assertEqual(len(view), 16)
+        self.assertEqual(view[:], data)
+        self.assertIsInstance(view[:], bytes)
+        self.assertEqual(view[5:-6], b'56789')
+        self.assertEqual(indexbytes(view, 7), ord('7'))
+        view = bytesview(view, 5)
+        self.assertEqual(view[:], b'56789ABCDEF')
+        self.assertEqual(indexbytes(view, 4), ord('9'))
+        view = bytesview(view, 0, 5)
+        self.assertEqual(view[:], b'56789')
+        self.assertEqual(indexbytes(view, 1), ord('6'))


### PR DESCRIPTION
With Python 2, slicing a buffer yield new data, but with Python 3, slicing a memoryview return another memoryview:

```python
> python2 -c 'print buffer(b"12345")[1:3].decode()'
23

> python3 -c 'print(memoryview(b"12345")[1:3].decode())'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: 'memoryview' object has no attribute 'decode'
```