### PR TITLE
support/unix_connect: improve Unix socket support

### DIFF
--- a/Xlib/support/unix_connect.py
+++ b/Xlib/support/unix_connect.py
@@ -86,8 +86,12 @@ def get_socket(dname, host, dno):
 
         # Else use Unix socket
         else:
+            address = '/tmp/.X11-unix/X%d' % dno
+            if not os.path.exists(address):
+                # Use abstract address.
+                address = '\0' + address
             s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            s.connect('/tmp/.X11-unix/X%d' % dno)
+            s.connect(address)
     except socket.error as val:
         raise error.DisplayConnectionError(dname, str(val))
 


### PR DESCRIPTION
Use an abstract address if no matching filesystem path is found. This is necessary when building a [snap package](http://snapcraft.io/) using `python-xlib`.

This can also be tested with:
```shell
> Xvfb -ac :42 &
> rm /tmp/.X11-unix/X42
> DISPLAY=:42 python -c 'from Xlib import display; display.Display()'
```