### PR TITLE
support/unix_connect: improve Xauthority handling

### DIFF
--- a/Xlib/support/unix_connect.py
+++ b/Xlib/support/unix_connect.py
@@ -118,7 +118,11 @@ def new_get_auth(sock, dname, host, dno):
         family = xauth.FamilyLocal
         addr = socket.gethostname().encode()
 
-    au = xauth.Xauthority()
+    try:
+        au = xauth.Xauthority()
+    except error.XauthError:
+        return b'', b''
+
     while 1:
         try:
             return au.get_best_auth(family, addr, dno)

--- a/Xlib/xauth.py
+++ b/Xlib/xauth.py
@@ -85,7 +85,7 @@ class Xauthority(object):
                     break
 
                 self.entries.append((family, addr, num, name, data))
-        except struct.error as e:
+        except struct.error:
             print("Xlib.xauth: warning, failed to parse part of xauthority file {0}, aborting all further parsing".format(filename))
 
         if len(self.entries) == 0:

--- a/Xlib/xauth.py
+++ b/Xlib/xauth.py
@@ -44,7 +44,7 @@ class Xauthority(object):
         try:
             raw = open(filename, 'rb').read()
         except IOError as err:
-            raise error.XauthError('~/.Xauthority: %s' % err)
+            raise error.XauthError('could not read from {0}: {1}'.format(filename, err))
 
         self.entries = []
 


### PR DESCRIPTION
Be more lenient if `$XAUTHFILE` / `~/.Xauthority` does not exist. This fixes #66.