### PR TITLE
Rework tests handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,9 @@ install:
   - pip install -r requirements.txt
   - pip install -r dev-requirements.txt
 
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-  - xauth generate :99.0 . trusted
-
 # command to run tests
-script: 
-  nosetests --exe --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --verbosity=3 test/ examples/run_examples.py
+script:
+  python runtests.py --with-coverage --cover-html --cover-html-dir=Coverage_report
 
 after_success:
   - codecov

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+# Python 2/3 compatibility.
+from __future__ import print_function
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+
+from pkg_resources import load_entry_point
+
+
+class SigException(BaseException):
+    def __init__(self, signum):
+        super(SigException, self).__init__()
+        self.signum = signum
+
+def xsession_sighandler(signum, frame):
+    raise SigException(signum)
+
+def xserver_start(display, executable='Xvfb', authfile=None):
+    pid = os.fork()
+    if pid != 0:
+        return pid
+    if authfile is None:
+        authfile = os.devnull
+    # This will make the xserver send us a SIGUSR1 when ready.
+    signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+    cmd = [
+        executable,
+        '-auth', authfile,
+        '-noreset',
+        display,
+    ]
+    print('starting xserver: `{0}`'.format(' '.join(cmd)))
+    os.execlp(cmd[0], *cmd)
+
+def tests_run(display, authfile=None):
+    pid = os.fork()
+    if pid != 0:
+        return pid
+    if authfile is None:
+        authfile = os.devnull
+    os.environ['DISPLAY'] = display
+    os.environ['XAUTHORITY'] = authfile
+    cmd = [
+        'nosetests',
+        '--exe', '--with-xunit', '--verbosity=3',
+    ]
+    has_custom_tests = False
+    for arg in sys.argv[1:]:
+        if not arg.startswith('-'):
+            has_custom_tests = True
+        cmd.append(arg)
+    if not has_custom_tests:
+        cmd.extend(('test/', 'examples/run_examples.py'))
+    print('running tests: `{0}`'.format(' '.join(cmd)))
+    sys.argv = cmd
+    try:
+        load_entry_point('nose', 'console_scripts', 'nosetests')()
+    except SystemExit as err:
+        code = err.code
+    else:
+        code = 0
+    os._exit(code)
+
+
+def runtests():
+
+    cleanup_funcs = []
+
+    try:
+        if hasattr(sys, 'pypy_version_info'):
+            server_display = ':8'
+        else:
+            server_display = ':9'
+        server_display += ''.join(str(n) for n in sys.version_info[:3])
+
+        # Setup a temporary authentication file.
+        cookie = subprocess.check_output('mcookie').strip()
+        authfile = tempfile.NamedTemporaryFile(delete=False)
+        cleanup_funcs.append(lambda: os.unlink(authfile.name))
+        authfile.close()
+        subprocess.check_call((
+            'xauth',
+            '-f', authfile.name,
+            'add', server_display, '.', cookie,
+        ))
+
+        # Setup signal handler to wait for xserver to be ready.
+        signal.signal(signal.SIGUSR1, xsession_sighandler)
+
+        # Start xserver.
+        server_pid = xserver_start(server_display, authfile=authfile.name)
+        cleanup_funcs.append(lambda: os.waitpid(server_pid, 0))
+        cleanup_funcs.append(lambda: os.kill(server_pid, signal.SIGTERM))
+
+        # Give the server 3 seconds to start.
+        signal.alarm(3)
+
+        # Wait for server to be ready.
+        try:
+            signal.pause()
+        except SigException as err:
+            assert signal.SIGUSR1 == err.signum
+            signal.alarm(0)
+
+        # Run tests.
+        tests_pid = tests_run(server_display, authfile=authfile.name)
+        pid, status = os.waitpid(tests_pid, 0)
+        assert pid == tests_pid
+        sys.exit(status >> 8)
+
+    except KeyboardInterrupt:
+        sys.exit(1)
+
+    finally:
+        for func in reversed(cleanup_funcs):
+            func()
+
+
+if __name__ == '__main__':
+    runtests()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py33,py34,py35
+skip_missing_interpreters = true
+
+[testenv]
+deps=
+	nose
+	six>=1.10.0
+commands={envpython} runtests.py {posargs}


### PR DESCRIPTION
* add helper script to run tests: `runtests.py` will handle starting `Xvfb` and running `nose` with the appropriate arguments
* add [tox](https://pypi.python.org/pypi/tox/2.5.0) configuration so it's easier to test locally for different Python versions

Note: `runtests.py` will pick different display numbers based on the Python version used, so it's possible to use [detox](https://pypi.python.org/pypi/detox/0.10.0) to run tests in parallel.