### PR TITLE
Import tohex in tests

### DIFF
--- a/test/test_events_be.py
+++ b/test/test_events_be.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.normpath(os.path.join(__file__, '../..')))
 import unittest
 from Xlib.protocol import request, event
 from . import BigEndianTest as EndianTest
-from . import DummyDisplay
+from . import DummyDisplay, tohex
 
 dummy_display = DummyDisplay()
 

--- a/test/test_requests_be.py
+++ b/test/test_requests_be.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.normpath(os.path.join(__file__, '../..')))
 import unittest
 from Xlib.protocol import request, event
 from . import BigEndianTest as EndianTest
-from . import DummyDisplay
+from . import DummyDisplay, tohex
 
 dummy_display = DummyDisplay()
 


### PR DESCRIPTION
This fixes the NameError:
```
ERROR: testPackReply0 (test.test_requests_be.TestAllocColor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/python-xlib-0.19/test/test_requests_be.py", line 3824, in testPackReply0
    assert bin == self.reply_bin_0
AssertionError
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/builddir/build/BUILD/python-xlib-0.19/test/test_requests_be.py", line 3826, in testPackReply0
    raise AssertionError(tohex(bin))
NameError: name 'tohex' is not defined
```