### PR TITLE
Fix xauth unclosed file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
 # command to run tests
 script:
-  python runtests.py --with-coverage --cover-html --cover-html-dir=Coverage_report
+  python -W all runtests.py --with-coverage --cover-html --cover-html-dir=Coverage_report
 
 after_success:
   - codecov

--- a/Xlib/xauth.py
+++ b/Xlib/xauth.py
@@ -42,7 +42,8 @@ class Xauthority(object):
                     '$HOME not set, cannot find ~/.Xauthority')
 
         try:
-            raw = open(filename, 'rb').read()
+            with open(filename, 'rb') as fp:
+                raw = fp.read()
         except IOError as err:
             raise error.XauthError('could not read from {0}: {1}'.format(filename, err))
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ skip_missing_interpreters = true
 deps=
 	nose
 	six>=1.10.0
-commands={envpython} runtests.py {posargs}
+commands={envpython} -W all runtests.py {posargs}


### PR DESCRIPTION
Fix the following Python warning: `Xlib/xauth.py:45: ResourceWarning: unclosed file`.

Note: I've also enabled all Python warnings during Travis/tox tests run, so we can detect similar issues earlier.