### PR TITLE
Small tests releated improvements

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,7 @@ comment:
   layout: header, changes, diff
 coverage:
   ignore:
+  - examples/.*
   - test/.*
   status:
     patch: false

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 coverage
 codecov
+nose
 setuptools-scm

--- a/runtests.py
+++ b/runtests.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import textwrap
 
 from pkg_resources import load_entry_point
 
@@ -46,7 +47,15 @@ def tests_run(display, authfile=None):
     os.environ['DISPLAY'] = display
     os.environ['XAUTHORITY'] = authfile
     cmd = [
-        'nosetests',
+        sys.executable,
+        '-c', textwrap.dedent(
+            '''
+            from pkg_resources import load_entry_point
+            sys.exit(load_entry_point(
+                'nose', 'console_scripts', 'nosetests',
+            )())
+            '''
+        ).lstrip(),
         '--exe', '--with-xunit', '--verbosity=3',
     ]
     has_custom_tests = False

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,6 @@ skip_missing_interpreters = true
 
 [testenv]
 deps=
-	nose
-	six>=1.10.0
+	-rdev-requirements.txt
+	-rrequirements.txt
 commands={envpython} -W all runtests.py {posargs}


### PR DESCRIPTION
- add `nose` to development requirements
- runtests: fix subprocess call to run tests; make sure the correct Python interpreter is used
- tox: use requirements files to specify dependencies
- codecov: ignore examples/

