### PR TITLE
Corrected missing last letter in variable name.

### DIFF
--- a/Xlib/display.py
+++ b/Xlib/display.py
@@ -814,7 +814,7 @@ class Display(object):
         request.ChangePointerControl(display = self.display,
                                      onerror = onerror,
                                      do_accel = do_accel,
-                                     do_thres = do_threshold,
+                                     do_thresh = do_threshold,
                                      accel_num = accel_num,
                                      accel_denum = accel_denum,
                                      threshold = threshold)


### PR DESCRIPTION
class ChangePointerControl in request.py expects 'do_thresh', but display.py file provides 'do_thres'.

from Xlib import X, XK, display
disp = display.Display()
disp.change_pointer_control((1,1),1)

returns following traceback before introducing change (aka fixing mispelling), but not after

Traceback (most recent call last):    
  File "<stdin>", line 1, in <module>
  File "/home/hostname/.local/lib/python3.5/site-packages/Xlib/display.py", line 820, in change_pointer_control
    threshold = threshold)                   
  File "/home/hostname/.local/lib/python3.5/site-packages/Xlib/protocol/rq.py", line 1347, in __init__
    self._binary = self._request.to_binary(*args, **keys)             
  File "/home/hostname/.local/lib/python3.5/site-packages/Xlib/protocol/rq.py", line 1004, in to_binary
    raise TypeError("Missing required argument {0}".format(f.name))
TypeError: Missing required argument do_thresh
