### PR TITLE
xobject/drawable: fix `put_pil_image` implementation

### DIFF
--- a/Xlib/xobject/drawable.py
+++ b/Xlib/xobject/drawable.py
@@ -249,7 +249,7 @@ class Drawable(resource.Resource):
             else:
                 subimage = image
             w, h = subimage.size
-            data = subimage.tostring("raw", rawmode, stride, 0)
+            data = subimage.tobytes("raw", rawmode, stride, 0)
             self.put_image(gc, x, y, w, h, format, depth, 0, data)
             y1 = y1 + h
             y = y + h


### PR DESCRIPTION
The deprecated `Image.tostring` method has been removed in Pillow>=3.0. Fix #105.