### PR TITLE
protocol/rq: fix string decoding

### DIFF
--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -35,7 +35,7 @@ from ..support import lock
 
 
 def decode_string(bs):
-    return bs.decode('ascii')
+    return bs.decode('latin1')
 
 if PY3:
     def encode_array(a):


### PR DESCRIPTION
Looks like I was wrong in #92: using ASCII can cause issues (see https://github.com/openstenoproject/plover/issues/919). As it turns out character strings should be decoded using Latin-1, see for example: https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html#requests:InternAtom.
