### PR TITLE
fix increasing memory usage on display instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 NEWS for Python X Library
 
-In development
+Version 0.25
 ==============
 
 Bug Fixes
 ---------
 
 - fix increasing memory usage on display instantiation
+- implement NV-CONTROL extension by Roberto Leinardi (@leinardi)
 
 ---
 Version 0.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ Bug Fixes
 ---------
 
 - fix increasing memory usage on display instantiation
-- implement NV-CONTROL extension by Roberto Leinardi (@leinardi)
+
+NV-CONTROL extension
+--------------------
+
+- add first implementation by Roberto Leinardi (@leinardi)
 
 ---
 Version 0.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 NEWS for Python X Library
 
 Version 0.25
-==============
+============
 
 Bug Fixes
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 NEWS for Python X Library
 
+In development
+==============
+
+Bug Fixes
+---------
+
+- fix increasing memory usage on display instantiation
+
+---
 Version 0.24
 ============
 

--- a/Xlib/display.py
+++ b/Xlib/display.py
@@ -62,12 +62,12 @@ _resource_hierarchy = {
     }
 
 class _BaseDisplay(protocol_display.Display):
-    resource_classes = _resource_baseclasses.copy()
 
     # Implement a cache of atom names, used by Window objects when
     # dealing with some ICCCM properties not defined in Xlib.Xatom
 
     def __init__(self, *args, **keys):
+        self.resource_classes = _resource_baseclasses.copy()
         protocol_display.Display.__init__(self, *args, **keys)
         self._atom_cache = {}
 

--- a/Xlib/protocol/display.py
+++ b/Xlib/protocol/display.py
@@ -76,7 +76,6 @@ else:
 
 
 class Display(object):
-    resource_classes = {}
     extension_major_opcodes = {}
     error_classes = error.xerror_class.copy()
     event_classes = event.event_class.copy()


### PR DESCRIPTION
Move finalized classes for resource types at the instance level, to avoid creating recursive class hierarchies.

Fix #136.