### PR TITLE
Damage ext example

### DIFF
--- a/Xlib/ext/__init__.py
+++ b/Xlib/ext/__init__.py
@@ -36,6 +36,7 @@ __extensions__ = [
     ('XFIXES', 'xfixes'),
     ('SECURITY', 'security'),
     ('XInputExtension', 'xinput'),
+    ('DAMAGE', 'damage'),
     ]
 
 __all__ = map(lambda x: x[1], __extensions__)

--- a/Xlib/ext/damage.py
+++ b/Xlib/ext/damage.py
@@ -94,7 +94,6 @@ def damage_create(self, level):
                  drawable=self.id,
                  level=level,
                  )
-    print('damage create')
     return did
 
 class DamageDestroy(rq.Request):
@@ -111,7 +110,6 @@ def damage_destroy(self, damage):
                   )
 
     self.display.free_resource_id(damage)
-    print('damage destroy')
 
 class DamageSubtract(rq.Request):
     _request = rq.Struct(rq.Card8('opcode'),
@@ -128,7 +126,6 @@ def damage_subtract(self, damage, repair=X.NONE, parts=X.NONE):
                    damage=damage,
                    repair=repair,
                    parts=parts)
-    print('damage subtract')
 
 class DamageAdd(rq.Request):
     _request = rq.Struct(rq.Card8('opcode'),
@@ -143,7 +140,6 @@ def damage_add(self, repair, parts):
               opcode=self.display.get_extension_major(extname),
               repair=repair,
               parts=parts)
-    print('damage add')
 
 # Events #
 

--- a/Xlib/ext/damage.py
+++ b/Xlib/ext/damage.py
@@ -1,0 +1,186 @@
+# Xlib.ext.damage -- DAMAGE extension module
+#
+#    Copyright (C) 2018 Joseph Kogut <joseph.kogut@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+#    Free Software Foundation, Inc.,
+#    59 Temple Place,
+#    Suite 330,
+#    Boston, MA 02111-1307 USA
+
+
+from Xlib import X
+from Xlib.protocol import rq, structs
+from Xlib.xobject import resource
+from Xlib.error import XError
+
+extname = 'DAMAGE'
+
+# Event codes #
+DamageNotifyCode = 0
+
+# Error codes #
+BadDamageCode = 0
+
+class BadDamageError(XError):
+    pass
+
+# DamageReportLevel options
+DamageReportRawRectangles = 0
+DamageReportDeltaRectangles = 1
+DamageReportBoundingBox = 2
+DamageReportNonEmpty = 3
+
+DamageReportLevel = (
+    DamageReportRawRectangles,
+    DamageReportDeltaRectangles,
+    DamageReportBoundingBox,
+    DamageReportNonEmpty,
+)
+
+DAMAGE = rq.Card32
+
+# Methods
+
+class QueryVersion(rq.ReplyRequest):
+    _request = rq.Struct(rq.Card8('opcode'),
+                         rq.Opcode(0),
+                         rq.RequestLength(),
+                         rq.Card32('major_version'),
+                         rq.Card32('minor_version'),
+                         )
+
+    _reply = rq.Struct(rq.ReplyCode(),
+                       rq.Pad(1),
+                       rq.Card16('sequence_number'),
+                       rq.ReplyLength(),
+                       rq.Card32('major_version'),
+                       rq.Card32('minor_version'),
+                       rq.Pad(16),
+                       )
+
+def query_version(self):
+    return QueryVersion(display=self.display,
+                        opcode=self.display.get_extension_major(extname),
+                        major_version=1,
+                        minor_version=1)
+
+class DamageCreate(rq.Request):
+    _request = rq.Struct(rq.Card8('opcode'),
+                         rq.Opcode(1),
+                         rq.RequestLength(),
+                         DAMAGE('damage'),
+                         rq.Drawable('drawable'),
+                         rq.Set('level', 1, DamageReportLevel),
+                         rq.Pad(3),
+                         )
+
+def damage_create(self, level):
+    did = self.display.allocate_resource_id()
+    DamageCreate(display=self.display,
+                 opcode=self.display.get_extension_major(extname),
+                 damage=did,
+                 drawable=self.id,
+                 level=level,
+                 )
+    print('damage create')
+    return did
+
+class DamageDestroy(rq.Request):
+    _request = rq.Struct(rq.Card8('opcode'),
+                         rq.Opcode(2),
+                         rq.RequestLength(),
+                         DAMAGE('damage')
+                         )
+
+def damage_destroy(self, damage):
+    DamageDestroy(display=self.display,
+                  opcode=self.display.get_extension_major(extname),
+                  damage=damage,
+                  )
+
+    self.display.free_resource_id(damage)
+    print('damage destroy')
+
+class DamageSubtract(rq.Request):
+    _request = rq.Struct(rq.Card8('opcode'),
+                         rq.Opcode(3),
+                         rq.RequestLength(),
+                         DAMAGE('damage'),
+                         rq.Card32('repair'),
+                         rq.Card32('parts')
+                         )
+
+def damage_subtract(self, damage, repair=X.NONE, parts=X.NONE):
+    DamageSubtract(display=self.display,
+                   opcode=self.display.get_extension_major(extname),
+                   damage=damage,
+                   repair=repair,
+                   parts=parts)
+    print('damage subtract')
+
+class DamageAdd(rq.Request):
+    _request = rq.Struct(rq.Card8('opcode'),
+                         rq.Opcode(4),
+                         rq.RequestLength(),
+                         rq.Card32('repair'),
+                         rq.Card32('parts'),
+                         )
+
+def damage_add(self, repair, parts):
+    DamageAdd(display=self.display,
+              opcode=self.display.get_extension_major(extname),
+              repair=repair,
+              parts=parts)
+    print('damage add')
+
+# Events #
+
+class DamageNotify(rq.Event):
+    _code = None
+    _fields = rq.Struct(
+        rq.Card8('type'),
+        rq.Card8('level'),
+        rq.Card16('sequence_number'),
+        rq.Drawable('drawable'),
+        DAMAGE('damage'),
+        rq.Card32('timestamp'),
+        rq.Object('area', structs.Rectangle),
+        rq.Object('drawable_geometry', structs.Rectangle)
+        )
+
+def init(disp, info):
+    disp.extension_add_method('display',
+                              'damage_query_version',
+                              query_version)
+
+    disp.extension_add_method('drawable',
+                              'damage_create',
+                              damage_create)
+
+    disp.extension_add_method('display',
+                              'damage_destroy',
+                              damage_destroy)
+
+    disp.extension_add_method('display',
+                              'damage_subtract',
+                              damage_subtract)
+
+    disp.extension_add_method('drawable',
+                              'damage_add',
+                              damage_add)
+
+    disp.extension_add_event(info.first_event + DamageNotifyCode, DamageNotify)
+
+    disp.add_extension_error(code=BadDamageCode, err=BadDamageError)

--- a/examples/xdamage.py
+++ b/examples/xdamage.py
@@ -76,7 +76,7 @@ def main():
     d = display.Display()
     root = d.screen().root
 
-    checkExt(d)
+    check_ext(d)
     colormap = d.screen().default_colormap
 
     red = colormap.alloc_named_color("red").pixel

--- a/examples/xdamage.py
+++ b/examples/xdamage.py
@@ -2,7 +2,7 @@
 #
 # examples/xdamage.py -- demonstrate damage extension
 #
-#    Copyright (C) 2002 Peter Liljenberg <petli@ctrl-c.liu.se>
+#    Copyright (C) 2019 Mohit Garg <mrmohitgarg1990@gmail.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public License
@@ -36,6 +36,7 @@ import time
 import thread
 from Xlib.ext import damage
 from PIL import Image, ImageTk
+import traceback
 
 def redraw(win, gc):
     # win.clear_area()
@@ -50,14 +51,14 @@ def blink(display, win, gc, cols):
         redraw(win, gc)
         display.flush()
 
-def getImageFromWin(win,ptW,ptH,ptX=0,ptY=0):
+def get_image_from_win(win, pt_w, pt_h, pt_x=0, pt_y=0):
     try:
         raw = win.get_image(ptX,ptY, ptW,ptH, X.ZPixmap, 0xffffffff)
         image = Image.frombytes("RGB", (ptW, ptH), raw.data, "raw", "BGRX")
         return image
 
     except Exception:
-        print("exception thrown in getImageFromWin")
+        traceback.print_exc()
 
 def checkExt(disp):
     # Check for extension
@@ -69,7 +70,7 @@ def checkExt(disp):
             sys.exit(1)
     else:
         r = disp.damage_query_version()
-        print('DAMAGE version %d.%d' % (r.major_version, r.minor_version))
+        print('DAMAGE version %d.%d'.format(r.major_version, r.minor_version))
     
 def main():
     d = display.Display()
@@ -120,9 +121,9 @@ def main():
             if event.count == 0:
                 redraw(window1, gc)
         elif event.type == d.extension_event.DamageNotify:
-            image = getImageFromWin(window1, event.area.width, event.area.height, event.area.x, event.area.y)
-            bgpm = window2.create_pixmap(image.width,image.height,d.screen().root_depth)
-            bggc = window2.create_gc(foreground=0,background=0)
+            image = get_image_from_win(window1, event.area.width, event.area.height, event.area.x, event.area.y)
+            bgpm = window2.create_pixmap(image.width, image.height, d.screen().root_depth)
+            bggc = window2.create_gc(foreground=0, background=0)
             bgpm.put_pil_image(bggc, 0, 0, image)
             window2.copy_area(bggc, bgpm, 0, 0, image.width, image.height, 0, 0)
             # bggc.free()

--- a/examples/xdamage.py
+++ b/examples/xdamage.py
@@ -70,7 +70,7 @@ def checkExt(disp):
             sys.exit(1)
     else:
         r = disp.damage_query_version()
-        print('DAMAGE version %d.%d'.format(r.major_version, r.minor_version))
+        print('DAMAGE version {}.{}'.format(r.major_version, r.minor_version))
     
 def main():
     d = display.Display()

--- a/examples/xdamage.py
+++ b/examples/xdamage.py
@@ -60,7 +60,7 @@ def get_image_from_win(win, pt_w, pt_h, pt_x=0, pt_y=0):
     except Exception:
         traceback.print_exc()
 
-def checkExt(disp):
+def check_ext(disp):
     # Check for extension
     if not disp.has_extension('DAMAGE'):
         sys.stderr.write('server does not have the DAMAGE extension\n')

--- a/examples/xdamage.py
+++ b/examples/xdamage.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+#
+# examples/xdamage.py -- demonstrate damage extension
+#
+#    Copyright (C) 2002 Peter Liljenberg <petli@ctrl-c.liu.se>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+#    Free Software Foundation, Inc.,
+#    59 Temple Place,
+#    Suite 330,
+#    Boston, MA 02111-1307 USA
+
+
+# Python 2/3 compatibility.
+from __future__ import print_function
+
+import sys
+import os
+
+# Change path so we find Xlib
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from Xlib import display, X, threaded,Xutil
+import time
+import thread
+from Xlib.ext import damage
+from PIL import Image, ImageTk
+
+def redraw(win, gc):
+    # win.clear_area()
+    win.fill_rectangle(gc, 0, 0, 60, 60)
+
+def blink(display, win, gc, cols):
+    while 1:
+        time.sleep(2)
+        print('Changing color', cols[0])
+        gc.change(foreground = cols[0])
+        cols = (cols[1], cols[0])
+        redraw(win, gc)
+        display.flush()
+
+def getImageFromWin(win,ptW,ptH,ptX=0,ptY=0):
+    try:
+        raw = win.get_image(ptX,ptY, ptW,ptH, X.ZPixmap, 0xffffffff)
+        image = Image.frombytes("RGB", (ptW, ptH), raw.data, "raw", "BGRX")
+        return image
+
+    except Exception:
+        print("exception thrown in getImageFromWin")
+
+def checkExt(disp):
+    # Check for extension
+    if not disp.has_extension('DAMAGE'):
+        sys.stderr.write('server does not have the DAMAGE extension\n')
+        sys.stderr.write("\n".join(disp.list_extensions()))
+        
+        if disp.query_extension('DAMAGE') is None:
+            sys.exit(1)
+    else:
+        r = disp.damage_query_version()
+        print('DAMAGE version %d.%d' % (r.major_version, r.minor_version))
+    
+def main():
+    d = display.Display()
+    root = d.screen().root
+
+    checkExt(d)
+    colormap = d.screen().default_colormap
+
+    red = colormap.alloc_named_color("red").pixel
+    blue = colormap.alloc_named_color("blue").pixel
+    background = colormap.alloc_named_color("white").pixel
+
+    window1 = root.create_window(100, 100, 250, 100, 1,
+                                X.CopyFromParent, X.InputOutput,
+                                X.CopyFromParent,
+                                background_pixel = background,
+                                event_mask = X.StructureNotifyMask | X.ExposureMask)
+    window1.set_wm_name('Changing Window')
+    window1.map()
+    gc = window1.create_gc(foreground = red)
+    
+    thread.start_new_thread(blink, (d, window1, gc, (blue, red)))
+    
+    window1.damage_create(damage.DamageReportRawRectangles)
+    window1.set_wm_normal_hints(
+            flags=(Xutil.PPosition | Xutil.PSize | Xutil.PMinSize),
+            min_width=50,
+            min_height=50
+            )
+
+    window2 = root.create_window(100, 250, 250, 100, 1,
+                                X.CopyFromParent, X.InputOutput,
+                                X.CopyFromParent,
+                                background_pixel = background,
+                                event_mask = X.StructureNotifyMask | X.ExposureMask)
+    window2.set_wm_normal_hints(
+            flags=(Xutil.PPosition | Xutil.PSize | Xutil.PMinSize),
+            min_width=50,
+            min_height=50
+            )
+
+    window2.set_wm_name('Tracking Window')
+    window2.map()
+
+    while 1:
+        event = d.next_event()
+        if event.type == X.Expose:
+            if event.count == 0:
+                redraw(window1, gc)
+        elif event.type == d.extension_event.DamageNotify:
+            image = getImageFromWin(window1, event.area.width, event.area.height, event.area.x, event.area.y)
+            bgpm = window2.create_pixmap(image.width,image.height,d.screen().root_depth)
+            bggc = window2.create_gc(foreground=0,background=0)
+            bgpm.put_pil_image(bggc, 0, 0, image)
+            window2.copy_area(bggc, bgpm, 0, 0, image.width, image.height, 0, 0)
+            # bggc.free()
+        elif event.type == X.DestroyNotify:
+            sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This example demonstrates the use of the damage extension. This simple script creates 2 windows:
1.Changing Window - continuously changes color
2.Tracking Window  - displays the changed area in the Changing Window

The area notified by the damage extension notification will be painted in the second window.