### PR TITLE
Add check for older / non-compliant X servers

### DIFF
--- a/Xlib/ext/xinput.py
+++ b/Xlib/ext/xinput.py
@@ -647,8 +647,8 @@ def init(disp, info):
     disp.extension_add_method('display', 'xinput_ungrab_device', ungrab_device)
     disp.extension_add_method('window', 'xinput_grab_keycode', grab_keycode)
     disp.extension_add_method('window', 'xinput_ungrab_keycode', ungrab_keycode)
-
-    for device_event in (ButtonPress, ButtonRelease, KeyPress, KeyRelease, Motion):
-        disp.ge_add_event_data(info.major_opcode, device_event, DeviceEventData)
-    disp.ge_add_event_data(info.major_opcode, DeviceChanged, DeviceEventData)
-    disp.ge_add_event_data(info.major_opcode, HierarchyChanged, HierarchyEventData)
+    if hasattr(disp,"ge_add_event_data"):
+        for device_event in (ButtonPress, ButtonRelease, KeyPress, KeyRelease, Motion):
+            disp.ge_add_event_data(info.major_opcode, device_event, DeviceEventData)
+        disp.ge_add_event_data(info.major_opcode, DeviceChanged, DeviceEventData)
+        disp.ge_add_event_data(info.major_opcode, HierarchyChanged, HierarchyEventData)


### PR DESCRIPTION
The existing code library generates a fatal exception:

```
File "/usr/lib/python3/dist-packages/Xlib/display.py", line 127, in __init__
    mod.init(self, info)
  File "/usr/lib/python3/dist-packages/Xlib/ext/xinput.py", line 652, in init
    disp.ge_add_event_data(info.major_opcode, device_event, DeviceEventData)
  File "/usr/lib/python3/dist-packages/Xlib/display.py", line 227, in __getattr__
    raise AttributeError(attr)
AttributeError: ge_add_event_data

```
when connected to RealVNC's current xserver.
VNC(R) Server 6.4.1 (r40826) x64 (Mar 13 2019 16:27:00)
Copyright (C) 2002-2019 RealVNC Ltd.

This prevents the exception by testing for the presence of ge_add_event_data before calling it.

