### PR TITLE
Fix TypeError in socket.error exception handling

### DIFF
--- a/Xlib/protocol/display.py
+++ b/Xlib/protocol/display.py
@@ -582,7 +582,7 @@ class Display(object):
                 try:
                     i = self.socket.send(self.data_send)
                 except socket.error as err:
-                    self.close_internal('server: %s' % err[1])
+                    self.close_internal('server: %s' % err)
                     raise self.socket_error
 
                 self.data_send = self.data_send[i:]
@@ -600,7 +600,7 @@ class Display(object):
                         count = max(self.recv_buffer_size, count)
                         bytes_recv = self.socket.recv(count)
                     except socket.error as err:
-                        self.close_internal('server: %s' % err[1])
+                        self.close_internal('server: %s' % err)
                         raise self.socket_error
 
                     if not bytes_recv:


### PR DESCRIPTION
The socket.error, which is an alias to OSError since python 3.3, is not
subscriptable (and its subclasses neither are). Hence, pass the entire
exception message to close_internal().

In case of a socket.error in self.socket.send(), the former code crashed
with a TypeError.

I strongly suspect that this closes issue #127.