### PR TITLE
Add DPMS extension

### DIFF
--- a/Xlib/ext/__init__.py
+++ b/Xlib/ext/__init__.py
@@ -38,6 +38,7 @@ __extensions__ = [
     ('XInputExtension', 'xinput'),
     ('NV-CONTROL', 'nvcontrol'),
     ('DAMAGE', 'damage'),
+    ('DPMS', 'dpms'),
     ]
 
 __all__ = map(lambda x: x[1], __extensions__)

--- a/Xlib/ext/dpms.py
+++ b/Xlib/ext/dpms.py
@@ -1,0 +1,234 @@
+# Xlib.ext.dpms -- X Display Power Management Signaling
+#
+#    Copyright (C) 2020 Thiago Kenji Okada <thiagokada@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+#    Free Software Foundation, Inc.,
+#    59 Temple Place,
+#    Suite 330,
+#    Boston, MA 02111-1307 USA
+
+'''
+This extension provides X Protocol control over the VESA Display
+Power Management Signaling (DPMS) characteristics of video boards
+under control of the X Window System.
+
+Documentation: https://www.x.org/releases/X11R7.7/doc/xextproto/dpms.html
+'''
+
+from Xlib import X
+from Xlib.protocol import rq
+
+extname = 'DPMS'
+
+
+# DPMS Extension Power Levels
+#      0     DPMSModeOn          In use
+#      1     DPMSModeStandby     Blanked, low power
+#      2     DPMSModeSuspend     Blanked, lower power
+#      3     DPMSModeOff         Shut off, awaiting activity
+DPMSModeOn = 0
+DPMSModeStandby = 1
+DPMSModeSuspend = 2
+DPMSModeOff = 3
+
+DPMSPowerLevel = (
+    DPMSModeOn,
+    DPMSModeStandby,
+    DPMSModeSuspend,
+    DPMSModeOff,
+)
+
+
+class DPMSGetVersion(rq.ReplyRequest):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(0),
+        rq.RequestLength(),
+        rq.Card16('major_version'),
+        rq.Card16('minor_version'),
+        )
+
+    _reply = rq.Struct(
+            rq.ReplyCode(),
+            rq.Pad(1),
+            rq.Card16('sequence_number'),
+            rq.ReplyLength(),
+            rq.Card16('major_version'),
+            rq.Card16('minor_version'),
+            rq.Pad(20),
+            )
+
+
+def get_version(self):
+    return DPMSGetVersion(display=self.display,
+                          opcode=self.display.get_extension_major(extname),
+                          major_version=1,
+                          minor_version=1)
+
+
+class DPMSCapable(rq.ReplyRequest):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(1),
+        rq.RequestLength(),
+        )
+
+    _reply = rq.Struct(
+            rq.ReplyCode(),
+            rq.Pad(1),
+            rq.Card16('sequence_number'),
+            rq.ReplyLength(),
+            rq.Bool('capable'),
+            rq.Pad(23),
+            )
+
+
+def capable(self):
+    return DPMSCapable(display=self.display,
+                       opcode=self.display.get_extension_major(extname),
+                       major_version=1,
+                       minor_version=1)
+
+
+class DPMSGetTimeouts(rq.ReplyRequest):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(2),
+        rq.RequestLength(),
+        )
+
+    _reply = rq.Struct(
+            rq.ReplyCode(),
+            rq.Pad(1),
+            rq.Card16('sequence_number'),
+            rq.ReplyLength(),
+            rq.Card16('standby_timeout'),
+            rq.Card16('suspend_timeout'),
+            rq.Card16('off_timeout'),
+            rq.Pad(18),
+            )
+
+
+def get_timeouts(self):
+    return DPMSGetTimeouts(display=self.display,
+                           opcode=self.display.get_extension_major(extname),
+                           major_version=1,
+                           minor_version=1)
+
+
+class DPMSSetTimeouts(rq.Request):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(3),
+        rq.RequestLength(),
+        rq.Card16('standby_timeout'),
+        rq.Card16('suspend_timeout'),
+        rq.Card16('off_timeout'),
+        rq.Pad(2)
+        )
+
+
+def set_timeouts(self, standby_timeout, suspend_timeout, off_timeout):
+    return DPMSSetTimeouts(display=self.display,
+                           opcode=self.display.get_extension_major(extname),
+                           major_version=1,
+                           minor_version=1,
+                           standby_timeout=standby_timeout,
+                           suspend_timeout=suspend_timeout,
+                           off_timeout=off_timeout)
+
+
+class DPMSEnable(rq.Request):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(4),
+        rq.RequestLength(),
+        )
+
+
+def enable(self):
+    return DPMSEnable(display=self.display,
+                      opcode=self.display.get_extension_major(extname),
+                      major_version=1,
+                      minor_version=1)
+
+
+class DPMSDisable(rq.Request):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(5),
+        rq.RequestLength(),
+        )
+
+
+def disable(self):
+    return DPMSDisable(display=self.display,
+                       opcode=self.display.get_extension_major(extname),
+                       major_version=1,
+                       minor_version=1)
+
+
+class DPMSForceLevel(rq.Request):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(6),
+        rq.RequestLength(),
+        rq.Resource('power_level', DPMSPowerLevel),
+        )
+
+
+def force_level(self, power_level):
+    return DPMSForceLevel(display=self.display,
+                          opcode=self.display.get_extension_major(extname),
+                          major_version=1,
+                          minor_version=1,
+                          power_level=power_level)
+
+
+class DPMSInfo(rq.ReplyRequest):
+    _request = rq.Struct(
+        rq.Card8('opcode'),
+        rq.Opcode(7),
+        rq.RequestLength(),
+        )
+
+    _reply = rq.Struct(
+        rq.ReplyCode(),
+        rq.Pad(1),
+        rq.Card16('sequence_number'),
+        rq.ReplyLength(),
+        rq.Resource('power_level', DPMSPowerLevel),
+        rq.Bool('state'),
+        rq.Pad(21),
+        )
+
+
+def info(self):
+    return DPMSInfo(display=self.display,
+                    opcode=self.display.get_extension_major(extname),
+                    major_version=1,
+                    minor_version=1)
+
+
+def init(disp, info):
+    disp.extension_add_method('display', 'dpms_get_version', get_version)
+    disp.extension_add_method('display', 'dpms_capable', capable)
+    disp.extension_add_method('display', 'dpms_get_timeouts', get_timeouts)
+    disp.extension_add_method('display', 'dpms_set_timeouts', set_timeouts)
+    disp.extension_add_method('display', 'dpms_enable', enable)
+    disp.extension_add_method('display', 'dpms_disable', disable)
+    disp.extension_add_method('display', 'dpms_force_level', force_level)
+    # TODO: Returns 'TypeError: first argument must be callable' on call
+    # disp.extension_add_method('display', 'dpms_info', info)

--- a/examples/dpms.py
+++ b/examples/dpms.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+#
+# examples/dpms.py -- DPMS usage examples.
+#
+#    Copyright (C) 2020 Thiago Kenji Okada<thiagokokada@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+#    Free Software Foundation, Inc.,
+#    59 Temple Place,
+#    Suite 330,
+#    Boston, MA 02111-1307 USA
+
+import time
+
+from Xlib import display
+from Xlib.ext import dpms
+
+
+class DPMSExamples(object):
+    def __init__(self):
+        self.d = display.Display()
+        # Making sure that DPMS is enabled
+        self.d.dpms_enable()
+        # For some reason, the call above needs another X11 call
+        # to actually trigger it
+        self.d.dpms_get_version()
+
+    def dpms_info(self):
+        capable = self.d.dpms_capable()
+        timeouts = self.d.dpms_get_timeouts()
+
+        return (capable, timeouts)
+
+    def turn_off_display(self):
+        self.d.dpms_force_level(dpms.DPMSModeOff)
+        # For some reason, the call above needs another X11 call
+        # to actually trigger it
+        self.d.dpms_get_version()
+
+    def turn_on_display(self):
+        self.d.dpms_force_level(dpms.DPMSModeOn)
+        # For some reason, the call above needs another X11 call
+        # to actually trigger it
+        self.d.dpms_get_version()
+
+
+if __name__ == '__main__':
+    examples = DPMSExamples()
+
+    capable, timeouts = examples.dpms_info()
+
+    assert capable, 'DPMS is not supported in your system'
+
+    print('Current DPMS timeouts:')
+    print('Standby: {}, Suspend: {}, Off: {}'.format(
+        timeouts.standby_timeout,
+        timeouts.suspend_timeout,
+        timeouts.off_timeout
+    ))
+
+    print('\nThe next example will turn-off your screen, press Ctrl-C to cancel.')
+    time.sleep(2)
+    examples.turn_off_display()
+
+    print('\nTurning it on again...')
+    time.sleep(2)
+    examples.turn_on_display()


### PR DESCRIPTION
Based on the documentation found here: https://www.x.org/releases/X11R7.7/doc/xextproto/dpms.html

It basically works, however there are some known issues:
- Any `rq.Request` call (`dpms_enable()`, `dpms_set_timeouts()`, `dpms_force_level()`) only works if you call another `rq.ReplyRequest` function (`dpms_get_version()`, for example) afterwards. I tried to  change them to use `rq.ReplyRequest`, this worked but since they don't return anything they got stucked waiting for a response from X11. Maybe I am missing some call to another function?
- `DPMSInfo` doesn't work. I don't have a clue why, but it doesn't seem to be an issue with X11. I receive the following error when trying to call `dpms_info()`:

  ```
  $ cat playground.py
  from Xlib import display

  d = display.Display()
  print(d.dpms_info())

  $ python3 playground.py
  Traceback (most recent call last):
    File "playground.py", line 4, in <module>
      print(d.dpms_info())
    File "Xlib/display.py", line 225, in __getattr__
      return types.MethodType(function, self)
  TypeError: first argument must be callable
  ```

  So I decided to comment this function for now.

Since I am not familiar with the X11 protocol there may be something wrong, but I did some tests and it seems to work fine.

I only tested on Python 3.8, but I think it should work in Python 2 too since I didn't use anything incompatible.