### PR TITLE
Update links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,10 +75,10 @@ Documentation
 ~~~~~~~~~~~~~
 
 The reference manual is not finished by far, but is probably still useful. It
-can be `browsed online <http://python-xlib.sourceforge.net/doc/html/index.html>`__.
+can be `browsed online <https://python-xlib.github.io/>`__.
 
 There are also some `example programs <Examples_>`_ and, of course,
-`the standard X11 documentation <http://tronche.com/gui/x/xlib/>`__ applies.
+`the standard X11 documentation <https://tronche.com/gui/x/xlib/>`__ applies.
 
 
 Project status

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ There are three advantages of implementing a pure Python library:
 
 -  Maintainability: It is much easier to develop and debug native Python
    modules than modules written in C.
-   
+
 Documentation
 ~~~~~~~~~~~~~
 
@@ -92,7 +92,7 @@ starting with version 2.0.
 
 There is a resource database implementation, ICCCM support and a
 framework for adding X extension code. Several extensions have been
-implemented; (RECORD, SHAPE, Xinerama, Composite, RANDR, and XTEST)
+implemented; (RECORD, SHAPE, Xinerama, Composite, RANDR, DPMS, and XTEST)
 patches for additions are very welcome.
 
 There are most likely still bugs, but the library is at least stable


### PR DESCRIPTION
Update `python-xlib` documentation to point to https://python-xlib.github.io/, since https://github.com/python-xlib/python-xlib.github.io/pull/1 was merged.

Also update another link to use HTTPS instead of HTTP, since the site supports it (it actually does a redirect). There is still an older reference that does not support HTTPS, but the site still works, so keep it as is.

Add reference to DPMS in README.rst.