### PR TITLE
Use encode_array() in Drawable._get_struct_prop()

### DIFF
--- a/Xlib/xobject/drawable.py
+++ b/Xlib/xobject/drawable.py
@@ -779,7 +779,7 @@ class Window(Drawable):
     def _get_struct_prop(self, pname, ptype, pstruct):
         r = self.get_property(pname, ptype, 0, pstruct.static_size // 4)
         if r and r.format == 32:
-            value = r.value.tostring()
+            value = rq.encode_array(r.value)
             if len(value) == pstruct.static_size:
                 return pstruct.parse_binary(value, self.display)[0]
 


### PR DESCRIPTION
The Xlib/protocol/rq.py file defines an helper function encode_array()
that calls tostring() or tobytes() depending on which python version is
used.

The package maintainer Christoph Egger reported that the testsuite of
the herbstluftwm project fails[1] with the error:
```
      def _get_struct_prop(self, pname, ptype, pstruct):
          r = self.get_property(pname, ptype, 0, pstruct.static_size // 4)
          if r and r.format == 32:
  >           value = r.value.tostring()
  E           AttributeError: 'array.array' object has no attribute 'tostring'

    /usr/lib/python3/dist-packages/Xlib/xobject/drawable.py:782: AttributeError
```
Backtrace:

    ../tests/conftest.py:624: in is_window_urgent
        hints = window.get_wm_hints()
    /usr/lib/python3/dist-packages/Xlib/xobject/drawable.py:756: in get_wm_hints
        return self._get_struct_prop(Xatom.WM_HINTS, Xatom.WM_HINTS,

I assume it should be rq.encode_array() instead of .tostring() but I'm
not terribly sure.

[1] https://pbot.rmdir.de/u/4lU98VkXkdjSypXmdekh5g