### PR TITLE
Remove mock

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 coverage
 codecov
-mock
 nose
 setuptools-scm

--- a/test/test_unix_connect.py
+++ b/test/test_unix_connect.py
@@ -6,7 +6,10 @@ import socket
 import sys
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from Xlib.support import unix_connect
 from Xlib.error import DisplayConnectionError, DisplayNameError


### PR DESCRIPTION
Mock as a standalone package is not needed. Use the standard lib mock if available