### PR TITLE
Update xf86.py with new keysyms

### DIFF
--- a/Xlib/keysymdef/xf86.py
+++ b/Xlib/keysymdef/xf86.py
@@ -159,6 +159,25 @@ XK_XF86_Green           = 0x1008FFA4
 XK_XF86_Yellow          = 0x1008FFA5
 XK_XF86_Blue            = 0x1008FFA6
 
+XK_XF86_Suspend         = 0x1008FFA7
+XK_XF86_Hibernate       = 0x1008FFA8
+XK_XF86_TouchpadToggle  = 0x1008FFA9
+XK_XF86_TouchpadOn      = 0x1008FFB0
+XK_XF86_TouchpadOff     = 0x1008FFB1
+
+XK_XF86_AudioMicMute    = 0x1008FFB2
+
+XK_XF86_Keyboard        = 0x1008FFB3
+
+XK_XF86_WWAN            = 0x1008FFB4
+XK_XF86_RFKill          = 0x1008FFB5
+
+XK_XF86_AudioPreset     = 0x1008FFB6
+
+XK_XF86_RotationLockToggle = 0x1008FFB7
+
+XK_XF86_FullScreen      = 0x1008FFB8
+
 XK_XF86_Switch_VT_1     = 0x1008FE01
 XK_XF86_Switch_VT_2     = 0x1008FE02
 XK_XF86_Switch_VT_3     = 0x1008FE03

--- a/Xlib/keysymdef/xf86.py
+++ b/Xlib/keysymdef/xf86.py
@@ -1,8 +1,11 @@
-XK_XF86_MonBrightnessUp   = 0x1008FF02
-XK_XF86_MonBrightnessDown = 0x1008FF03
-XK_XF86_KbdLightOnOff     = 0x1008FF04
-XK_XF86_KbdBrightnessUp   = 0x1008FF05
-XK_XF86_KbdBrightnessDown = 0x1008FF06
+XK_XF86_ModeLock = 0x1008FF01
+
+XK_XF86_MonBrightnessUp    = 0x1008FF02
+XK_XF86_MonBrightnessDown  = 0x1008FF03
+XK_XF86_KbdLightOnOff      = 0x1008FF04
+XK_XF86_KbdBrightnessUp    = 0x1008FF05
+XK_XF86_KbdBrightnessDown  = 0x1008FF06
+XK_XF86_MonBrightnessCycle = 0x1008FF07
 
 XK_XF86_Standby          = 0x1008FF10
 XK_XF86_AudioLowerVolume = 0x1008FF11
@@ -195,3 +198,5 @@ XK_XF86_Ungrab          = 0x1008FE20
 XK_XF86_ClearGrab       = 0x1008FE21
 XK_XF86_Next_VMode      = 0x1008FE22
 XK_XF86_Prev_VMode      = 0x1008FE23
+XK_XF86_LogWindowTree	= 0x1008FE24
+XK_XF86_LogGrabInfo	= 0x1008FE25


### PR DESCRIPTION
Added keysyms:
- Suspend
- hibernate
- touchpad controls
- microphone toggle
- WWAN
- RFKill
- Audio preset
- rotation lock toggle
- full screen
- ModeLock
- MonBrightnessCycle
- LogWindowTree
- LogGrabInfo


These "new" keysyms were taken from `/usr/include/X11/XF86keysym.h` on my Ubuntu machine