### PR TITLE
Include _data attr keys in __dir__() for better introspection

### DIFF
--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -1297,6 +1297,12 @@ class GetAttrData(object):
         except KeyError:
             raise AttributeError(attr)
 
+    def __dir__(self):
+        attrs = super().__dir__()
+        if self._data:
+            attrs.extend(list(self._data.keys()))
+        return attrs
+
 class DictWrapper(GetAttrData):
     def __init__(self, dict):
         self.__dict__['_data'] = dict


### PR DESCRIPTION
Just adds a __dir__() method to protocol.rq.GetAttrData which allows the _data dict's keys to show as instance attributes. Allows for better introspection, and also enables auto-completion in, e.g., REPL. 