### PR TITLE
Include note about OS support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,9 @@ Requirements
 The Python X Library requires Python 2.7 or newer. It has been tested to
 various extents with Python 2.7 and 3.3 through 3.6.
 
+The Python X Library will only work on systems that have an X server installed,
+such as most Linux distros, but will not work on Windows or MacOS.
+
 Installation
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Originally when I tried to use this package I did not know about the OS requirement. This will leave a note about OS compatibility.

Fix #116 