### PR TITLE
Avoid to use fcntl module on some environments

### DIFF
--- a/test/test_unix_connect.py
+++ b/test/test_unix_connect.py
@@ -72,8 +72,8 @@ class TestUnixConnect(unittest.TestCase):
         def path_exists(returns, path):
             calls.append(('os.path.exists', path))
             return returns
-        def fcntl(*args):
-            calls.append(('fcntl',) + args)
+        def ensure_not_inheritable(*args):
+            calls.append(('ensure_not_inheritable',) + args)
         for params, allow_unix, unix_addr_exists, allow_tcp, expect_connection_error, expected_calls in (
             # Successful explicit TCP socket connection.
             (('tcp/host:6', None, 'host', 6), False, False, True, False, [
@@ -141,7 +141,7 @@ class TestUnixConnect(unittest.TestCase):
                           partial(_get_socket, 'tcp', not allow_tcp)), \
                     patch('os.path.exists',
                           partial(path_exists, unix_addr_exists)), \
-                    patch('fcntl.fcntl', fcntl):
+                    patch('Xlib.support.unix_connect._ensure_not_inheritable', ensure_not_inheritable):
                 del calls[:]
                 if expect_connection_error:
                     with self.assertRaises(DisplayConnectionError):
@@ -149,9 +149,7 @@ class TestUnixConnect(unittest.TestCase):
                 else:
                     s = unix_connect.get_socket(*params)
                     self.assertIsInstance(s, FakeSocket)
-                    expected_calls.append(('fcntl', 42,
-                                           unix_connect.F_SETFD,
-                                           unix_connect.FD_CLOEXEC))
+                    expected_calls.append(('ensure_not_inheritable', s))
                 self.assertEqual(calls, expected_calls)
 
 


### PR DESCRIPTION
Hi, thanks for the great python-xlib.
I want to use this library on Windows (without WSL), so I made this PR.
If you could review and merge this, I would be happy.

## What
This PR will make `unix_connect.get_socket` function to avoid using `fcntl` module on some environments and use [`socket.socket.set_inheritable`](https://docs.python.org/3.9/library/socket.html#socket.socket.set_inheritable) instead if possible.

## Why
[PEP446](https://www.python.org/dev/peps/pep-0446/) allows the use of `socket.socket.set_inheritable` in Python 3.4 and above versions. This seems to work basically in environments including Windows where socket module can be used. So if we can use it in an environment, we can use it to eliminate the dependency on `fcntl` module and improve the portability of python-xlib.