### PR TITLE
Provides support for version 1.5 of RANDR protocol

### DIFF
--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -604,7 +604,8 @@ class Object(ValueField):
         return self.type.parse_value(val, display)
 
     def pack_value(self, val):
-        return self.type.pack_value(val)
+        val = self.type.pack_value(val)
+        return val, len(val), None
 
     def check_value(self, val):
         if isinstance(val, tuple):


### PR DESCRIPTION
The following pull request provides the following updates:

* Support for RANDR v1.5 monitor methods (`RRSetMonitor`, `XRRDeleteMonitor`, `XRRGetMonitors`)
* A bug fix to `rq.py` that allows for proper packing of embedded `Object` fields in the request structs

