### PR TITLE
Fix screensaver protocol mismatch

### DIFF
--- a/Xlib/ext/screensaver.py
+++ b/Xlib/ext/screensaver.py
@@ -64,9 +64,9 @@ class QueryVersion(rq.ReplyRequest):
             rq.Pad(1),
             rq.Card16('sequence_number'),
             rq.ReplyLength(),
-            rq.Card8('major_version'),
-            rq.Card8('minor_version'),
-            rq.Pad(22),
+            rq.Card16('major_version'),
+            rq.Card16('minor_version'),
+            rq.Pad(20),
             )
 
 def query_version(self):
@@ -94,7 +94,7 @@ class QueryInfo(rq.ReplyRequest):
             rq.Card32('idle'),
             rq.Card32('event_mask'), # rq.Set('event_mask', 4, (NotifyMask, CycleMask)),
             rq.Card8('kind'),
-            rq.Pad(10),
+            rq.Pad(7),
             )
 
 def query_info(self):


### PR DESCRIPTION
The protocol encoding specified in the X11 documentation differs from the actual XCB protocol that Xorg uses. This makes `query_version()` report the wrong version and `query_info()` fail by trying to unpack too many bytes.