### PR TITLE
xauth: fix for auth entry having no display number

### DIFF
--- a/Xlib/xauth.py
+++ b/Xlib/xauth.py
@@ -120,6 +120,8 @@ class Xauthority(object):
         matches = {}
 
         for efam, eaddr, enum, ename, edata in self.entries:
+            if enum == b'' and ename not in matches:
+                enum = num
             if efam == family and eaddr == address and num == enum:
                 matches[ename] = edata
 


### PR DESCRIPTION
Fixes #207.

The patch comes from a suggestion in this Ubuntu bug report: https://bugs.launchpad.net/ubuntu/+source/python-xlib/+bug/1885304

I tested on a NixOS 22.05 system running GNOME 42.2. On this system, `xauth list` prints an authorization of the form `hostname/unix:` without a display number. I reproduced the issue and and validated the fix with this command:

```
nix-shell -p python3Packages.xlib --run "python -c 'from Xlib.display import Display; Display()'"
```

I'm unsure of the potential consequences of this patch, so a careful review is appreciated.