### PR TITLE
Fix Issue 233: Rename `add_extension_error` method

### DIFF
--- a/Xlib/display.py
+++ b/Xlib/display.py
@@ -340,8 +340,8 @@ class Display(object):
         # extension dict maintained in the display object
         setattr(self.extension_event, name, (code,subcode))
 
-    def add_extension_error(self, code, err):
-        """add_extension_error(code, err)
+    def extension_add_error(self, code, err):
+        """extension_add_error(code, err)
 
         Add an extension error.  CODE is the numeric code, and ERR is
         the error class.

--- a/Xlib/ext/damage.py
+++ b/Xlib/ext/damage.py
@@ -179,4 +179,4 @@ def init(disp, info):
 
     disp.extension_add_event(info.first_event + DamageNotifyCode, DamageNotify)
 
-    disp.add_extension_error(code=BadDamageCode, err=BadDamageError)
+    disp.extension_add_error(code=BadDamageCode, err=BadDamageError)

--- a/test/test_xlib_display.py
+++ b/test/test_xlib_display.py
@@ -87,7 +87,7 @@ class TestXlibDisplay(unittest.TestCase):
         self.assertRaises(AssertionError, self.display.extension_add_method, "font", "__init__", lambda x: x)
 
     def test_can_add_extension_error(self):
-        self.display.add_extension_error(1, Xlib.error.XError)
+        self.display.extension_add_error(1, Xlib.error.XError)
         self.assertEqual(self.display.display.error_classes[1], Xlib.error.XError)
 
     def test_keycode_to_keysym_for_invalid_index(self):


### PR DESCRIPTION
As reported in Issue #233, the xrandr functionality is unusable because of an error, which can be seen when `examples/xrandr.py` is run:

```
% python ./examples/xrandr.py
Traceback (most recent call last):
  File "/home/matt/python-xlib/./examples/../Xlib/display.py", line 224, in __getattr__
    function = self.display_extension_methods[attr]
KeyError: 'extension_add_error'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/matt/python-xlib/./examples/xrandr.py", line 196, in <module>
    Window(display.Display()).loop()
  File "/home/matt/python-xlib/./examples/../Xlib/display.py", line 127, in __init__
    mod.init(self, info)
  File "/home/matt/python-xlib/./examples/../Xlib/ext/randr.py", line 1291, in init
    disp.extension_add_error(BadRROutput, BadRROutputError)
  File "/home/matt/python-xlib/./examples/../Xlib/display.py", line 227, in __getattr__
    raise AttributeError(attr)
AttributeError: extension_add_error
```

The `test_xlib_display.py` test is also failing:

```
% python test/test_xlib_display.py
[...]
======================================================================
ERROR: test_set_get_pointer_mapping (__main__.TestXlibDisplay)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matt/Projects/displays-ws/python-xlib/test/../Xlib/display.py", line 224, in __getattr__
    function = self.display_extension_methods[attr]
KeyError: 'extension_add_error'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/matt/Projects/displays-ws/python-xlib/test/test_xlib_display.py", line 22, in setUp
    self.display = Xlib.display.Display(self.display_num)
  File "/home/matt/Projects/displays-ws/python-xlib/test/../Xlib/display.py", line 127, in __init__
    mod.init(self, info)
  File "/home/matt/Projects/displays-ws/python-xlib/test/../Xlib/ext/randr.py", line 1291, in init
    disp.extension_add_error(BadRROutput, BadRROutputError)
  File "/home/matt/Projects/displays-ws/python-xlib/test/../Xlib/display.py", line 227, in __getattr__
    raise AttributeError(attr)
AttributeError: extension_add_error

======================================================================
ERROR: test_set_modifier_mapping (__main__.TestXlibDisplay)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matt/Projects/displays-ws/python-xlib/test/../Xlib/display.py", line 224, in __getattr__
    function = self.display_extension_methods[attr]
KeyError: 'extension_add_error'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/matt/Projects/displays-ws/python-xlib/test/test_xlib_display.py", line 22, in setUp
    self.display = Xlib.display.Display(self.display_num)
  File "/home/matt/Projects/displays-ws/python-xlib/test/../Xlib/display.py", line 127, in __init__
    mod.init(self, info)
  File "/home/matt/Projects/displays-ws/python-xlib/test/../Xlib/ext/randr.py", line 1291, in init
    disp.extension_add_error(BadRROutput, BadRROutputError)
  File "/home/matt/Projects/displays-ws/python-xlib/test/../Xlib/display.py", line 227, in __getattr__
    raise AttributeError(attr)
AttributeError: extension_add_error

----------------------------------------------------------------------
Ran 40 tests in 0.178s

FAILED (errors=40)
```

After these changes are applied, both commands succeed.

Example:

```
% python ./examples/xrandr.py
RANDR version 1.5
Screen info:
{   'config_timestamp': 615389,
'n_rate_ents': 41,
'rate': 60,
'root': <Window 0x000007d8>,
'rotation': 1,
'sequence_number': 32,
'set_of_rotations': 63,
'size_id': 0,
'sizes': [   DictWrapper({'width_in_pixels': 3840, 'height_in_pixels': 1600, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
DictWrapper({'width_in_pixels': 2560, 'height_in_pixels': 1440, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
DictWrapper({'width_in_pixels': 1920, 'height_in_pixels': 1600, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
DictWrapper({'width_in_pixels': 2560, 'height_in_pixels': 1080, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
DictWrapper({'width_in_pixels': 1920, 'height_in_pixels': 1080, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
DictWrapper({'width_in_pixels': 1600, 'height_in_pixels': 1200, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
DictWrapper({'width_in_pixels': 1280, 'height_in_pixels': 1024, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
DictWrapper({'width_in_pixels': 1280, 'height_in_pixels': 800, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
DictWrapper({'width_in_pixels': 1152, 'height_in_pixels': 864, 'width_in_millimeters': 880, 'height_in_millimeters': 367}),
[...]
```

Test:

```
% python test/test_xlib_display.py
....../home/matt/python-xlib/test/../Xlib/protocol/rq.py:994: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
names = [f.name for f in self.fields \
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:994: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
names = [f.name for f in self.fields \
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:994: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
names = [f.name for f in self.fields \
ResourceWarning: Enable tracemalloc to get the object allocation traceback
............/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1360: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self._binary = self._request.to_binary(*args, **keys)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1360: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self._binary = self._request.to_binary(*args, **keys)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1360: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self._binary = self._request.to_binary(*args, **keys)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
........./home/matt/python-xlib/test/../Xlib/protocol/rq.py:1302: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self.__dict__['_data'] = dict
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1302: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self.__dict__['_data'] = dict
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1302: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self.__dict__['_data'] = dict
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1302: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self.__dict__['_data'] = dict
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1302: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self.__dict__['_data'] = dict
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1302: ResourceWarning: unclosed <socket.socket fd=11, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self.__dict__['_data'] = dict
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1302: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self.__dict__['_data'] = dict
ResourceWarning: Enable tracemalloc to get the object allocation traceback
.../home/matt/python-xlib/test/../Xlib/protocol/rq.py:994: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_UNIX,type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
names = [f.name for f in self.fields \
ResourceWarning: Enable tracemalloc to get the object allocation traceback
..../home/matt/python-xlib/test/../Xlib/protocol/rq.py:1360: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self._binary = self._request.to_binary(*args, **keys)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/matt/python-xlib/test/../Xlib/protocol/rq.py:1360: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/.X11-unix/X0>
self._binary = self._request.to_binary(*args, **keys)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
......
----------------------------------------------------------------------
Ran 40 tests in 0.267s

OK
```




































Environment

```
% python --version
Python 3.9.15
% uname -a
Linux m 6.0.2-arch1-1 #1 SMP PREEMPT_DYNAMIC Sat, 15 Oct 2022 14:00:49 +0000 x86_64 GNU/Linux
```

