### PR TITLE
Fix potential usage of None and Unbound variables issues

### DIFF
--- a/Xlib/ext/xinput.py
+++ b/Xlib/ext/xinput.py
@@ -226,8 +226,9 @@ class Mask(rq.List):
             # bytes we build a longer array, being careful to maintain native
             # byte order across the entire set of values.
             if sys.byteorder == 'little':
-                def fun(val):
-                    mask_seq.insert(0, val)
+                def fun(__v):
+                    # type: (int) -> None
+                    mask_seq.insert(0, __v)
             elif sys.byteorder == 'big':
                 fun = mask_seq.append
             else:
@@ -378,7 +379,7 @@ INFO_CLASSES = {
 }
 
 class ClassInfoClass(object):
-
+    check_value = None
     structcode = None
 
     def parse_binary(self, data, display):

--- a/Xlib/xobject/colormap.py
+++ b/Xlib/xobject/colormap.py
@@ -44,7 +44,7 @@ class Colormap(resource.Resource):
 
         self.display.free_resource_id(self.id)
 
-    def copy_colormap_and_free(self, scr_cmap):
+    def copy_colormap_and_free(self, src_cmap):
         mid = self.display.allocate_resource_id()
         request.CopyColormapAndFree(display = self.display,
                                     mid = mid,


### PR DESCRIPTION
- Misnamed `src_cmap`
- Uninitialized attributes and missing methods due to usage of similar classes that don't inherit the same bases
- Better defaults than `None` for variables and attributes when possible and `None` has no special meaning.
- Potentially unbound variables
- Additional Non checks or type coersion