### PR TITLE
Explicit arguments with *args and **kwargs

### DIFF
--- a/Xlib/display.py
+++ b/Xlib/display.py
@@ -66,9 +66,9 @@ class _BaseDisplay(protocol_display.Display):
     # Implement a cache of atom names, used by Window objects when
     # dealing with some ICCCM properties not defined in Xlib.Xatom
 
-    def __init__(self, *args, **keys):
+    def __init__(self, display = None, *args, **kwargs):
         self.resource_classes = _resource_baseclasses.copy()
-        protocol_display.Display.__init__(self, *args, **keys)
+        protocol_display.Display.__init__(self, display, *args, **kwargs)
         self._atom_cache = {}
 
     def get_atom(self, atomname, only_if_exists=0):

--- a/Xlib/ext/record.py
+++ b/Xlib/ext/record.py
@@ -215,9 +215,9 @@ class EnableContext(rq.ReplyRequest):
 
     # See the discussion on ListFonstsWithInfo in request.py
 
-    def __init__(self, callback, *args, **keys):
+    def __init__(self, callback, display, *args, defer = False, **keys):
         self._callback = callback
-        rq.ReplyRequest.__init__(self, *args, **keys)
+        rq.ReplyRequest.__init__(self, display, *args, defer=defer, **keys)
 
     def _parse_response(self, data):
         r, d = self._reply.parse_binary(data, self._display)

--- a/Xlib/ext/shape.py
+++ b/Xlib/ext/shape.py
@@ -220,7 +220,7 @@ def get_rectangles(self, source_kind):
         source_kind=source_kind,
     )
 
-def input_selected(self, ):
+def input_selected(self):
     return InputSelected(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -249,14 +249,14 @@ def offset(self, destination_kind, x_offset, y_offset):
         y_offset=y_offset,
     )
 
-def query_extents(self, ):
+def query_extents(self):
     return QueryExtents(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
         destination_window=self,
     )
 
-def query_version(self, ):
+def query_version(self):
     return QueryVersion(
         display=self.display,
         opcode=self.display.get_extension_major(extname),

--- a/Xlib/protocol/request.py
+++ b/Xlib/protocol/request.py
@@ -785,9 +785,9 @@ class ListFontsWithInfo(rq.ReplyRequest):
 
     # Bastards.
 
-    def __init__(self, *args, **keys):
+    def __init__(self, display, defer = False, *args, **keys):
         self._fonts = []
-        rq.ReplyRequest.__init__(self, *args, **keys)
+        rq.ReplyRequest.__init__(self, display, defer, *args, **keys)
 
     def _parse_response(self, data):
 


### PR DESCRIPTION
Usage of explicit arguments when known
Also removed a trailing comma