### PR TITLE
py.typed and type comments

### DIFF
--- a/Xlib/XK.py
+++ b/Xlib/XK.py
@@ -26,6 +26,7 @@
 from Xlib.X import NoSymbol
 
 def string_to_keysym(keysym):
+    # type: (str) -> int
     '''Return the (16 bit) numeric code of keysym.
 
     Given the name of a keysym as a string, return its numeric code.
@@ -34,6 +35,7 @@ def string_to_keysym(keysym):
     return globals().get('XK_' + keysym, NoSymbol)
 
 def load_keysym_group(group):
+    # type: (str) -> None
     '''Load all the keysyms in group.
 
     Given a group name such as 'latin1' or 'katakana' load the keysyms
@@ -68,6 +70,7 @@ load_keysym_group('latin1')
 
 
 def keysym_to_string(keysym):
+    # type: (int) -> str | None
     '''Translate a keysym (16 bit number) into a python string.
 
     This will pass 0 to 0xff as well as XK_BackSpace, XK_Tab, XK_Clear,

--- a/Xlib/display.py
+++ b/Xlib/display.py
@@ -533,7 +533,7 @@ class Display(object):
     ###
 
     def intern_atom(self, name, only_if_exists = 0):
-        # type: (str, int) -> int
+        # type: (str, bool) -> int
         """Intern the string name, returning its atom number. If
         only_if_exists is true and the atom does not already exist, it
         will not be created and X.NONE is returned."""
@@ -543,7 +543,7 @@ class Display(object):
         return r.atom
 
     def get_atom(self, atom, only_if_exists = 0):
-        # type: (str, int) -> int
+        # type: (str, bool) -> int
         """Alias for intern_atom, using internal cache"""
         return self.display.get_atom(atom, only_if_exists)
 

--- a/Xlib/error.py
+++ b/Xlib/error.py
@@ -25,9 +25,20 @@ from . import X
 # Xlib.protocol modules
 from .protocol import rq
 
+try:
+    from typing import TYPE_CHECKING, Any, Union
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from mmap import mmap
+    from array import array
+    from typing_extensions import TypeAlias, Literal
+    from Xlib.protocol import display
+    _SliceableBuffer: TypeAlias = Union[bytes, bytearray, memoryview, array[Any], mmap]
 
 class DisplayError(Exception):
     def __init__(self, display):
+        # type: (object) -> None
         self.display = display
 
     def __str__(self):
@@ -39,6 +50,7 @@ class DisplayNameError(DisplayError):
 
 class DisplayConnectionError(DisplayError):
     def __init__(self, display, msg):
+        # type: (object, object) -> None
         self.display = display
         self.msg = msg
 
@@ -47,6 +59,7 @@ class DisplayConnectionError(DisplayError):
 
 class ConnectionClosedError(Exception):
     def __init__(self, whom):
+        # type: (object) -> None
         self.whom = whom
 
     def __str__(self):
@@ -70,6 +83,7 @@ class XError(rq.GetAttrData, Exception):
                          )
 
     def __init__(self, display, data):
+        # type: (display.Display, _SliceableBuffer) -> None
         self._data, data = self._fields.parse_binary(data, display, rawdict = 1)
 
     def __str__(self):
@@ -131,11 +145,13 @@ xerror_class = {
 
 class CatchError(object):
     def __init__(self, *errors):
+        # type: (type[XError]) -> None
         self.error_types = errors
-        self.error = None
-        self.request = None
+        self.error = None # type: XError | None
+        self.request = None # type: rq.Request | None
 
     def __call__(self, error, request):
+        # type: (XError, rq.Request | None) -> Literal[0, 1]
         if self.error_types:
             for etype in self.error_types:
                 if isinstance(error, etype):

--- a/Xlib/ext/composite.py
+++ b/Xlib/ext/composite.py
@@ -37,6 +37,20 @@ from Xlib import X
 from Xlib.protocol import rq
 from Xlib.xobject import drawable
 
+try:
+    from typing import TYPE_CHECKING, TypeVar, Optional, Union
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import TypeAlias
+    from Xlib.error import XError
+    from Xlib.display import Display
+    from Xlib.xobject import resource
+    _T = TypeVar("_T")
+    _ErrorHandler: TypeAlias = Callable[[XError, Optional[rq.Request]], _T]
+    _Update: TypeAlias = Callable[[Union[rq.DictWrapper, dict[str, object]]], object]
+
 extname = 'Composite'
 
 RedirectAutomatic = 0
@@ -62,6 +76,7 @@ class QueryVersion(rq.ReplyRequest):
             )
 
 def query_version(self):
+    # type: (Display | resource.Resource) -> QueryVersion
     return QueryVersion(
         display = self.display,
         opcode = self.display.get_extension_major(extname),
@@ -81,6 +96,7 @@ class RedirectWindow(rq.Request):
         )
 
 def redirect_window(self, update, onerror = None):
+    # type: (drawable.Window, _Update, _ErrorHandler[object] | None) -> None
     """Redirect the hierarchy starting at this window to off-screen
     storage.
     """
@@ -103,6 +119,7 @@ class RedirectSubwindows(rq.Request):
         )
 
 def redirect_subwindows(self, update, onerror = None):
+    # type: (drawable.Window, _Update, _ErrorHandler[object] | None) -> None
     """Redirect the hierarchies starting at all current and future
     children to this window to off-screen storage.
     """
@@ -125,6 +142,7 @@ class UnredirectWindow(rq.Request):
         )
 
 def unredirect_window(self, update, onerror = None):
+    # type: (drawable.Window, _Update, _ErrorHandler[object] | None) -> None
     """Stop redirecting this window hierarchy.
     """
     UnredirectWindow(display = self.display,
@@ -146,6 +164,7 @@ class UnredirectSubindows(rq.Request):
         )
 
 def unredirect_subwindows(self, update, onerror = None):
+    # type: (drawable.Window, _Update, _ErrorHandler[object] | None) -> None
     """Stop redirecting the hierarchies of children to this window.
     """
     RedirectWindow(display = self.display,
@@ -166,6 +185,7 @@ class CreateRegionFromBorderClip(rq.Request):
         )
 
 def create_region_from_border_clip(self, onerror = None):
+    # type: (drawable.Window, _ErrorHandler[object] | None) -> int
     """Create a region of the border clip of the window, i.e. the area
     that is not clipped by the parent and any sibling windows.
     """
@@ -193,6 +213,7 @@ class NameWindowPixmap(rq.Request):
         )
 
 def name_window_pixmap(self, onerror = None):
+    # type: (drawable.Window, _ErrorHandler[object] | None) -> drawable.Pixmap
     """Create a new pixmap that refers to the off-screen storage of
     the window, including its border.
 
@@ -231,6 +252,7 @@ class GetOverlayWindow(rq.ReplyRequest):
     )
 
 def get_overlay_window(self):
+    # type: (Display | resource.Resource) -> GetOverlayWindow
     """Return the overlay window of the root window.
     """
 
@@ -239,6 +261,7 @@ def get_overlay_window(self):
                               window = self)
 
 def init(disp, info):
+    # type: (Display, object) -> None
     disp.extension_add_method('display',
                               'composite_query_version',
                               query_version)

--- a/Xlib/ext/damage.py
+++ b/Xlib/ext/damage.py
@@ -21,9 +21,10 @@
 
 
 from Xlib import X
-from Xlib.protocol import rq, structs
-from Xlib.xobject import resource
+from Xlib.protocol import rq, structs, request
 from Xlib.error import XError
+from Xlib.display import Display
+from Xlib.xobject import resource
 
 extname = 'DAMAGE'
 
@@ -71,6 +72,7 @@ class QueryVersion(rq.ReplyRequest):
                        )
 
 def query_version(self):
+    # type: (Display | resource.Resource) -> QueryVersion
     return QueryVersion(display=self.display,
                         opcode=self.display.get_extension_major(extname),
                         major_version=1,
@@ -87,6 +89,7 @@ class DamageCreate(rq.Request):
                          )
 
 def damage_create(self, level):
+    # type: (Display | resource.Resource, int) -> int
     did = self.display.allocate_resource_id()
     DamageCreate(display=self.display,
                  opcode=self.display.get_extension_major(extname),
@@ -104,6 +107,7 @@ class DamageDestroy(rq.Request):
                          )
 
 def damage_destroy(self, damage):
+    # type: (Display | resource.Resource, int) -> None
     DamageDestroy(display=self.display,
                   opcode=self.display.get_extension_major(extname),
                   damage=damage,
@@ -121,6 +125,7 @@ class DamageSubtract(rq.Request):
                          )
 
 def damage_subtract(self, damage, repair=X.NONE, parts=X.NONE):
+    # type: (Display | resource.Resource, int, int, int) -> None
     DamageSubtract(display=self.display,
                    opcode=self.display.get_extension_major(extname),
                    damage=damage,
@@ -136,6 +141,7 @@ class DamageAdd(rq.Request):
                          )
 
 def damage_add(self, repair, parts):
+    # type: (Display | resource.Resource, int, int) -> None
     DamageAdd(display=self.display,
               opcode=self.display.get_extension_major(extname),
               repair=repair,
@@ -157,6 +163,7 @@ class DamageNotify(rq.Event):
         )
 
 def init(disp, info):
+    # type: (Display, request.QueryExtension) -> None
     disp.extension_add_method('display',
                               'damage_query_version',
                               query_version)

--- a/Xlib/ext/dpms.py
+++ b/Xlib/ext/dpms.py
@@ -29,6 +29,8 @@ Documentation: https://www.x.org/releases/X11R7.7/doc/xextproto/dpms.html
 
 from Xlib import X
 from Xlib.protocol import rq
+from Xlib.display import Display
+from Xlib.xobject import resource
 
 extname = 'DPMS'
 
@@ -72,6 +74,7 @@ class DPMSGetVersion(rq.ReplyRequest):
 
 
 def get_version(self):
+    # type: (Display | resource.Resource) -> DPMSGetVersion
     return DPMSGetVersion(display=self.display,
                           opcode=self.display.get_extension_major(extname),
                           major_version=1,
@@ -96,6 +99,7 @@ class DPMSCapable(rq.ReplyRequest):
 
 
 def capable(self):
+    # type: (Display | resource.Resource) -> DPMSCapable
     return DPMSCapable(display=self.display,
                        opcode=self.display.get_extension_major(extname),
                        major_version=1,
@@ -122,6 +126,7 @@ class DPMSGetTimeouts(rq.ReplyRequest):
 
 
 def get_timeouts(self):
+    # type: (Display | resource.Resource) -> DPMSGetTimeouts
     return DPMSGetTimeouts(display=self.display,
                            opcode=self.display.get_extension_major(extname),
                            major_version=1,
@@ -141,6 +146,7 @@ class DPMSSetTimeouts(rq.Request):
 
 
 def set_timeouts(self, standby_timeout, suspend_timeout, off_timeout):
+    # type: (Display | resource.Resource, int, int, int) -> DPMSSetTimeouts
     return DPMSSetTimeouts(display=self.display,
                            opcode=self.display.get_extension_major(extname),
                            major_version=1,
@@ -159,6 +165,7 @@ class DPMSEnable(rq.Request):
 
 
 def enable(self):
+    # type: (Display | resource.Resource) -> DPMSEnable
     return DPMSEnable(display=self.display,
                       opcode=self.display.get_extension_major(extname),
                       major_version=1,
@@ -174,6 +181,7 @@ class DPMSDisable(rq.Request):
 
 
 def disable(self):
+    # type: (Display | resource.Resource) -> DPMSDisable
     return DPMSDisable(display=self.display,
                        opcode=self.display.get_extension_major(extname),
                        major_version=1,
@@ -190,6 +198,7 @@ class DPMSForceLevel(rq.Request):
 
 
 def force_level(self, power_level):
+    # type: (Display | resource.Resource, int) -> DPMSForceLevel
     return DPMSForceLevel(display=self.display,
                           opcode=self.display.get_extension_major(extname),
                           major_version=1,
@@ -216,6 +225,7 @@ class DPMSInfo(rq.ReplyRequest):
 
 
 def info(self):
+    # type: (Display | resource.Resource) -> DPMSInfo
     return DPMSInfo(display=self.display,
                     opcode=self.display.get_extension_major(extname),
                     major_version=1,
@@ -223,6 +233,7 @@ def info(self):
 
 
 def init(disp, _info):
+    # type: (Display, object) -> None
     disp.extension_add_method('display', 'dpms_get_version', get_version)
     disp.extension_add_method('display', 'dpms_capable', capable)
     disp.extension_add_method('display', 'dpms_get_timeouts', get_timeouts)

--- a/Xlib/ext/ge.py
+++ b/Xlib/ext/ge.py
@@ -25,6 +25,18 @@ ge - Generic Event Extension
 '''
 
 from Xlib.protocol import rq
+try:
+    from typing import TYPE_CHECKING, Union, Any
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from Xlib.display import Display
+    from Xlib.protocol import display
+    from Xlib.xobject import resource
+    from mmap import mmap
+    from array import array
+    from typing_extensions import TypeAlias
+    _SliceableBuffer: TypeAlias = Union[bytes, bytearray, memoryview, array[Any], mmap]
 
 extname = 'Generic Event Extension'
 
@@ -52,6 +64,7 @@ class GEQueryVersion(rq.ReplyRequest):
 
 
 def query_version(self):
+    # type: (Display | resource.Resource) -> GEQueryVersion
     return GEQueryVersion(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -77,6 +90,7 @@ class GenericEvent(rq.Event):
         )
 
     def __init__(self, binarydata = None, display = None, **keys):
+        # type: (_SliceableBuffer | None, display.Display | None, object) -> None
         if binarydata:
             data = binarydata[10:]
             binarydata = binarydata[:10]
@@ -101,12 +115,14 @@ class GenericEvent(rq.Event):
 
 
 def add_event_data(self, extension, evtype, estruct):
+    # type: (Display | resource.Resource, int, int, int) -> None
     if not hasattr(self.display, 'ge_event_data'):
         self.display.ge_event_data = {}
     self.display.ge_event_data[(extension, evtype)] = estruct
 
 
 def init(disp, info):
+    # type: (Display, object) -> None
     disp.extension_add_method('display', 'ge_query_version', query_version)
     disp.extension_add_method('display', 'ge_add_event_data', add_event_data)
     disp.extension_add_event(GenericEventCode, GenericEvent)

--- a/Xlib/ext/nvcontrol.py
+++ b/Xlib/ext/nvcontrol.py
@@ -23,11 +23,14 @@
 """NV-CONTROL - provide access to the NV-CONTROL extension information."""
 
 from Xlib.protocol import rq
+from Xlib.display import Display
+from Xlib.xobject import resource
 
 extname = 'NV-CONTROL'
 
 
 def query_target_count(self, target):
+    # type: (Display | resource.Resource, Target) -> int
     """Return the target count"""
     reply = NVCtrlQueryTargetCountReplyRequest(display=self.display,
                                                opcode=self.display.get_extension_major(extname),
@@ -36,6 +39,7 @@ def query_target_count(self, target):
 
 
 def query_int_attribute(self, target, display_mask, attr):
+    # type: (Display | resource.Resource, Target, int, int) -> int | None
     """Return the value of an integer attribute"""
     reply = NVCtrlQueryAttributeReplyRequest(display=self.display,
                                              opcode=self.display.get_extension_major(extname),
@@ -49,6 +53,7 @@ def query_int_attribute(self, target, display_mask, attr):
 
 
 def set_int_attribute(self, target, display_mask, attr, value):
+    # type: (Display | resource.Resource, Target, int, int, int) -> bool
     """Set the value of an integer attribute"""
     reply = NVCtrlSetAttributeAndGetStatusReplyRequest(display=self.display,
                                                        opcode=self.display.get_extension_major(extname),
@@ -61,6 +66,7 @@ def set_int_attribute(self, target, display_mask, attr, value):
 
 
 def query_string_attribute(self, target, display_mask, attr):
+    # type: (Display | resource.Resource, Target, int, int) -> str | None
     """Return the value of a string attribute"""
     reply = NVCtrlQueryStringAttributeReplyRequest(display=self.display,
                                                    opcode=self.display.get_extension_major(extname),
@@ -74,6 +80,7 @@ def query_string_attribute(self, target, display_mask, attr):
 
 
 def query_valid_attr_values(self, target, display_mask, attr):
+    # type: (Display | resource.Resource, Target, int, int) -> tuple[int, int] | None
     """Return the value of an integer attribute"""
     reply = NVCtrlQueryValidAttributeValuesReplyRequest(display=self.display,
                                                         opcode=self.display.get_extension_major(extname),
@@ -87,6 +94,7 @@ def query_valid_attr_values(self, target, display_mask, attr):
 
 
 def query_binary_data(self, target, display_mask, attr):
+    # type: (Display | resource.Resource, Target, int, int) -> bytes | None
     """Return binary data"""
     reply = NVCtrlQueryBinaryDataReplyRequest(display=self.display,
                                               opcode=self.display.get_extension_major(extname),
@@ -100,6 +108,7 @@ def query_binary_data(self, target, display_mask, attr):
 
 
 def get_coolers_used_by_gpu(self, target):
+    # type: (Display | resource.Resource, Target) -> bytes | None
     reply = NVCtrlQueryListCard32ReplyRequest(display=self.display,
                                               opcode=self.display.get_extension_major(extname),
                                               target_id=target.id(),
@@ -116,30 +125,36 @@ def get_coolers_used_by_gpu(self, target):
 
 
 def get_gpu_count(self):
+    # type: (Display | resource.Resource) -> int
     """Return the number of GPU's present in the system."""
     return int(query_target_count(self, Gpu()))
 
 
 def get_name(self, target):
+    # type: (Display | resource.Resource, Target) -> str | None
     """Return the GPU product name on which the specified X screen is running"""
     return query_string_attribute(self, target, 0, NV_CTRL_STRING_PRODUCT_NAME)
 
 
 def get_driver_version(self, target):
+    # type: (Display | resource.Resource, Target) -> str | None
     """Return the NVIDIA (kernel level) driver version for the specified screen or GPU"""
     return query_string_attribute(self, target, 0, NV_CTRL_STRING_NVIDIA_DRIVER_VERSION)
 
 
 def get_vbios_version(self, target):
+    # type: (Display | resource.Resource, Target) -> str | None
     """Return the version of the VBIOS for the specified screen or GPU"""
     return query_string_attribute(self, target, 0, NV_CTRL_STRING_VBIOS_VERSION)
 
 
 def get_gpu_uuid(self, target):
+    # type: (Display | resource.Resource, Target) -> str | None
     return query_string_attribute(self, target, 0, NV_CTRL_STRING_GPU_UUID)
 
 
 def get_utilization_rates(self, target):
+    # type: (Display | resource.Resource, Target) -> dict[str, str | int]
     string = query_string_attribute(self, target, 0, NV_CTRL_STRING_GPU_UTILIZATION)
     result = {}
     if string is not None and string != '':
@@ -150,6 +165,7 @@ def get_utilization_rates(self, target):
 
 
 def get_performance_modes(self, target):
+    # type: (Display | resource.Resource, Target) -> list[dict[str, str | int]]
     string = query_string_attribute(self, target, 0, NV_CTRL_STRING_PERFORMANCE_MODES)
     result = []
     if string is not None and string != '':
@@ -163,6 +179,7 @@ def get_performance_modes(self, target):
 
 
 def get_clock_info(self, target):
+    # type: (Display | resource.Resource, Target) -> dict[str, str | int]
     string = query_string_attribute(self, target, 0, NV_CTRL_STRING_GPU_CURRENT_CLOCK_FREQS)
     result = {}
     if string is not None and string != '':
@@ -173,15 +190,18 @@ def get_clock_info(self, target):
 
 
 def get_vram(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_VIDEO_RAM)
 
 
 def get_irq(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return the interrupt request line used by the GPU driving the screen"""
     return query_int_attribute(self, target, 0, NV_CTRL_IRQ)
 
 
 def supports_framelock(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return whether the underlying GPU supports Frame Lock.
 
     All of the other frame lock attributes are only applicable if this returns True.
@@ -190,6 +210,7 @@ def supports_framelock(self, target):
 
 
 def gvo_supported(self, screen):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return whether this X screen supports GVO
 
     If this screen does not support GVO output, then all other GVO attributes are unavailable.
@@ -198,11 +219,13 @@ def gvo_supported(self, screen):
 
 
 def get_core_temp(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return the current core temperature of the GPU driving the X screen."""
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_CORE_TEMPERATURE)
 
 
 def get_core_threshold(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return the current GPU core slowdown threshold temperature.
 
     It reflects the temperature at which the GPU is throttled to prevent overheating.
@@ -211,113 +234,140 @@ def get_core_threshold(self, target):
 
 
 def get_default_core_threshold(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return the default core threshold temperature."""
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_DEFAULT_CORE_THRESHOLD)
 
 
 def get_max_core_threshold(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return the maximum core threshold temperature."""
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_MAX_CORE_THRESHOLD)
 
 
 def get_ambient_temp(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return the current temperature in the immediate neighbourhood of the GPU driving the X screen."""
     return query_int_attribute(self, target, 0, NV_CTRL_AMBIENT_TEMPERATURE)
 
 
 def get_cuda_cores(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_CORES)
 
 
 def get_memory_bus_width(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_MEMORY_BUS_WIDTH)
 
 
 def get_total_dedicated_gpu_memory(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_TOTAL_DEDICATED_GPU_MEMORY)
 
 
 def get_used_dedicated_gpu_memory(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_USED_DEDICATED_GPU_MEMORY)
 
 
 def get_curr_pcie_link_width(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_PCIE_CURRENT_LINK_WIDTH)
 
 
 def get_max_pcie_link_width(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_PCIE_MAX_LINK_WIDTH)
 
 
 def get_curr_pcie_link_generation(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_PCIE_GENERATION)
 
 
 def get_encoder_utilization(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_VIDEO_ENCODER_UTILIZATION)
 
 
 def get_decoder_utilization(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_VIDEO_DECODER_UTILIZATION)
 
 
 def get_current_performance_level(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_CURRENT_PERFORMANCE_LEVEL)
 
 
 def get_gpu_nvclock_offset(self, target, perf_level):
+    # type: (Display | resource.Resource, Target, int) -> int | None
     return query_int_attribute(self, target, perf_level, NV_CTRL_GPU_NVCLOCK_OFFSET)
 
 
 def set_gpu_nvclock_offset(self, target, perf_level, offset):
+    # type: (Display | resource.Resource, Target, int, int) -> bool
     return set_int_attribute(self, target, perf_level, NV_CTRL_GPU_NVCLOCK_OFFSET, offset)
 
 
 def set_gpu_nvclock_offset_all_levels(self, target, offset):
+    # type: (Display | resource.Resource, Target, int) -> bool
     return set_int_attribute(self, target, 0, NV_CTRL_GPU_NVCLOCK_OFFSET_ALL_PERFORMANCE_LEVELS, offset)
 
 
 def get_gpu_nvclock_offset_range(self, target, perf_level):
+    # type: (Display | resource.Resource, Target, int) -> tuple[int, int] | None
     return query_valid_attr_values(self, target, perf_level, NV_CTRL_GPU_NVCLOCK_OFFSET)
 
 
 def get_mem_transfer_rate_offset(self, target, perf_level):
+    # type: (Display | resource.Resource, Target, int) -> int | None
     return query_int_attribute(self, target, perf_level, NV_CTRL_GPU_MEM_TRANSFER_RATE_OFFSET)
 
 
 def set_mem_transfer_rate_offset(self, target, perf_level, offset):
+    # type: (Display | resource.Resource, Target, int, int) -> bool
     return set_int_attribute(self, target, perf_level, NV_CTRL_GPU_MEM_TRANSFER_RATE_OFFSET, offset)
 
 
 def set_mem_transfer_rate_offset_all_levels(self, target, offset):
+    # type: (Display | resource.Resource, Target, int) -> bool
     return set_int_attribute(self, target, 0, NV_CTRL_GPU_MEM_TRANSFER_RATE_OFFSET_ALL_PERFORMANCE_LEVELS, offset)
 
 
 def get_mem_transfer_rate_offset_range(self, target, perf_level):
+    # type: (Display | resource.Resource, Target, int) -> tuple[int, int] | None
     return query_valid_attr_values(self, target, perf_level, NV_CTRL_GPU_MEM_TRANSFER_RATE_OFFSET)
 
 
 def get_cooler_manual_control_enabled(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_GPU_COOLER_MANUAL_CONTROL)
 
 
 def set_cooler_manual_control_enabled(self, target, enabled):
+    # type: (Display | resource.Resource, Target, bool) -> bool
     return set_int_attribute(self, target, 0, NV_CTRL_GPU_COOLER_MANUAL_CONTROL, 1 if enabled else 0) == 1
 
 
 def get_fan_duty(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_THERMAL_COOLER_CURRENT_LEVEL)
 
 
 def set_fan_duty(self, cooler, speed):
+    # type: (Display | resource.Resource, Target, int) -> bool
     return set_int_attribute(self, cooler, 0, NV_CTRL_THERMAL_COOLER_LEVEL, speed)
 
 
 def get_fan_rpm(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     return query_int_attribute(self, target, 0, NV_CTRL_THERMAL_COOLER_SPEED)
 
 
 def get_max_displays(self, target):
+    # type: (Display | resource.Resource, Target) -> int | None
     """Return the maximum number of display devices that can be driven simultaneously on a GPU.
 
     Note that this does not indicate the maximum number of bits that can be set in
@@ -354,6 +404,7 @@ def _displays2mask(displays):
 
 
 def init(disp, info):
+    # type: (Display, object) -> None
     disp.extension_add_method('display', 'nvcontrol_query_target_count', query_target_count)
     disp.extension_add_method('display', 'nvcontrol_query_int_attribute', query_int_attribute)
     disp.extension_add_method('display', 'nvcontrol_query_string_attribute', query_string_attribute)
@@ -5199,6 +5250,7 @@ class Target(object):
 
 class Gpu(Target):
     def __init__(self, ngpu=0):
+        # type: (int) -> None
         """Target a GPU"""
         super(self.__class__, self).__init__()
         self._id = ngpu
@@ -5208,6 +5260,7 @@ class Gpu(Target):
 
 class Screen(Target):
     def __init__(self, nscr=0):
+        # type: (int) -> None
         """Target an X screen"""
         super(self.__class__, self).__init__()
         self._id = nscr
@@ -5217,6 +5270,7 @@ class Screen(Target):
 
 class Cooler(Target):
     def __init__(self, nfan=0):
+        # type: (int) -> None
         """Target a fann"""
         super(self.__class__, self).__init__()
         self._id = nfan

--- a/Xlib/ext/randr.py
+++ b/Xlib/ext/randr.py
@@ -37,6 +37,16 @@ http://www.x.org/releases/X11R7.5/doc/randrproto/randrproto.txt
 from tkinter import W
 from Xlib import X
 from Xlib.protocol import rq, structs
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from Xlib import error
+    from Xlib.display import Display
+    from Xlib.protocol import request
+    from Xlib.xobject import resource, drawable
+    from collections.abc import Sequence
 
 extname = 'RANDR'
 
@@ -210,6 +220,7 @@ class QueryVersion(rq.ReplyRequest):
         )
 
 def query_version(self):
+    # type: (Display | resource.Resource) -> QueryVersion
     """Get the current version of the RandR extension.
 
     """
@@ -285,6 +296,7 @@ class SetScreenConfig(rq.ReplyRequest):
         )
 
 def set_screen_config(self, size_id, rotation, config_timestamp, rate=0, timestamp=X.CurrentTime):
+    # type: (drawable.Drawable, int, int, int, int, int) -> SetScreenConfig
     """Sets the screen to the specified size, rate, rotation and reflection.
 
     rate can be 0 to have the server select an appropriate rate.
@@ -313,6 +325,7 @@ class SelectInput(rq.Request):
         )
 
 def select_input(self, mask):
+    # type: (drawable.Window, int) -> SelectInput
     return SelectInput(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -347,6 +360,7 @@ class GetScreenInfo(rq.ReplyRequest):
         )
 
 def get_screen_info(self):
+    # type: (drawable.Window) -> GetScreenInfo
     """Retrieve information about the current and available configurations for
     the screen associated with this window.
 
@@ -380,6 +394,7 @@ class GetScreenSizeRange(rq.ReplyRequest):
         )
 
 def get_screen_size_range(self):
+    # type: (drawable.Window) -> GetScreenSizeRange
     """Retrieve the range of possible screen sizes. The screen may be set to
 	any size within this range.
 
@@ -404,6 +419,7 @@ class SetScreenSize(rq.Request):
         )
 
 def set_screen_size(self, width, height, width_in_millimeters=None, height_in_millimeters=None):
+    # type: (drawable.Window, int, int, int | None, int | None) -> SetScreenSize
     return SetScreenSize(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -441,6 +457,7 @@ class GetScreenResources(rq.ReplyRequest):
         )
 
 def get_screen_resources(self):
+    # type: (drawable.Window) -> GetScreenResources
     return GetScreenResources(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -479,6 +496,7 @@ class GetOutputInfo(rq.ReplyRequest):
         )
 
 def get_output_info(self, output, config_timestamp):
+    # type: (Display | resource.Resource, int, int) -> GetOutputInfo
     return GetOutputInfo(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -505,6 +523,7 @@ class ListOutputProperties(rq.ReplyRequest):
         )
 
 def list_output_properties(self, output):
+    # type: (Display | resource.Resource, int) -> ListOutputProperties
     return ListOutputProperties (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -533,6 +552,7 @@ class QueryOutputProperty(rq.ReplyRequest):
         )
 
 def query_output_property(self, output, property):
+    # type: (Display | resource.Resource, int, int) -> QueryOutputProperty
     return QueryOutputProperty (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -555,6 +575,7 @@ class ConfigureOutputProperty (rq.Request):
         )
 
 def configure_output_property (self, output, property):
+    # type: (Display | resource.Resource, int, int) -> ConfigureOutputProperty
     return ConfigureOutputProperty (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -579,6 +600,7 @@ class ChangeOutputProperty(rq.Request):
         )
 
 def change_output_property(self, output, property, type, mode, value):
+    # type: (Display | resource.Resource, int, int, int, int, Sequence[float] | Sequence[str]) -> ChangeOutputProperty
     return ChangeOutputProperty(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -600,6 +622,7 @@ class DeleteOutputProperty(rq.Request):
         )
 
 def delete_output_property(self, output, property):
+    # type: (Display | resource.Resource, int, int) -> DeleteOutputProperty
     return DeleteOutputProperty(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -635,6 +658,7 @@ class GetOutputProperty(rq.ReplyRequest):
         )
 
 def get_output_property(self, output, property, type, long_offset, long_length, delete=False, pending=False):
+    # type: (Display | resource.Resource, int, int, int, int, int, bool, bool) -> GetOutputProperty
     return GetOutputProperty(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -667,6 +691,7 @@ class CreateMode(rq.ReplyRequest):
         )
 
 def create_mode(self, mode, name):
+    # type: (drawable.Window, tuple[int, int, int, int, int, int, int, int, int, int, int, int, int], str) -> CreateMode
     return CreateMode (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -685,6 +710,7 @@ class DestroyMode(rq.Request):
         )
 
 def destroy_mode(self, mode):
+    # type: (Display | resource.Resource, int) -> DestroyMode
     return DestroyMode(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -702,6 +728,7 @@ class AddOutputMode(rq.Request):
         )
 
 def add_output_mode(self, output, mode):
+    # type: (Display | resource.Resource, int, int) -> AddOutputMode
     return AddOutputMode(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -720,6 +747,7 @@ class DeleteOutputMode(rq.Request):
         )
 
 def delete_output_mode(self, output, mode):
+    # type: (Display | resource.Resource, int, int) -> DeleteOutputMode
     return DeleteOutputMode(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -756,6 +784,7 @@ class GetCrtcInfo(rq.ReplyRequest):
         )
 
 def get_crtc_info(self, crtc, config_timestamp):
+    # type: (Display | resource.Resource, int, int) -> GetCrtcInfo
     return GetCrtcInfo (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -789,6 +818,7 @@ class SetCrtcConfig(rq.ReplyRequest):
         )
 
 def set_crtc_config(self, crtc, config_timestamp, x, y, mode, rotation, outputs, timestamp=X.CurrentTime):
+    # type: (Display | resource.Resource, int, int, int, int, int, int, Sequence[int], int) -> SetCrtcConfig
     return SetCrtcConfig (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -820,6 +850,7 @@ class GetCrtcGammaSize(rq.ReplyRequest):
         )
 
 def get_crtc_gamma_size(self, crtc):
+    # type: (Display | resource.Resource, int) -> GetCrtcGammaSize
     return GetCrtcGammaSize (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -847,6 +878,7 @@ class GetCrtcGamma(rq.ReplyRequest):
         )
 
 def get_crtc_gamma(self, crtc):
+    # type: (Display | resource.Resource, int) -> GetCrtcGamma
     return GetCrtcGamma (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -868,6 +900,7 @@ class SetCrtcGamma(rq.Request):
         )
 
 def set_crtc_gamma(self, crtc, size, red, green, blue):
+    # type: (Display | resource.Resource, int, int, Sequence[int], Sequence[int], Sequence[int]) -> SetCrtcGamma
     return SetCrtcGamma(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -907,6 +940,7 @@ class GetScreenResourcesCurrent(rq.ReplyRequest):
         )
 
 def get_screen_resources_current(self):
+    # type: (drawable.Window) -> GetScreenResourcesCurrent
     return GetScreenResourcesCurrent(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -928,6 +962,7 @@ class SetCrtcTransform(rq.Request):
         )
 
 def set_crtc_transform(self, crtc, n_bytes_filter):
+    # type: (Display | resource.Resource, int, Sequence[int]) -> SetCrtcTransform
     return SetCrtcTransform(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -964,6 +999,7 @@ class GetCrtcTransform(rq.ReplyRequest):
         )
 
 def get_crtc_transform(self, crtc):
+    # type: (Display | resource.Resource, int) -> GetCrtcTransform
     return GetCrtcTransform(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -999,6 +1035,7 @@ class GetPanning(rq.ReplyRequest):
         )
 
 def get_panning(self, crtc):
+    # type: (Display | resource.Resource, int) -> GetPanning
     return GetPanning (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -1036,6 +1073,7 @@ class SetPanning(rq.ReplyRequest):
         )
 
 def set_panning(self, crtc, left, top, width, height, track_left, track_top, track_width, track_height, border_left, border_top, border_width, border_height, timestamp=X.CurrentTime):
+    # type: (Display | resource.Resource, int, int, int, int, int, int, int, int, int, int, int, int, int, int) -> SetPanning
     return SetPanning (
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -1066,6 +1104,7 @@ class SetOutputPrimary(rq.Request):
         )
 
 def set_output_primary(self, output):
+    # type: (drawable.Window, int) -> SetOutputPrimary
     return SetOutputPrimary(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -1091,6 +1130,7 @@ class GetOutputPrimary(rq.ReplyRequest):
         )
 
 def get_output_primary(self):
+    # type: (drawable.Window) -> GetOutputPrimary
     return GetOutputPrimary(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -1124,6 +1164,7 @@ class GetMonitors(rq.ReplyRequest):
 
 
 def get_monitors(self, is_active=True):
+    # type: (drawable.Window, bool) -> GetMonitors
     return GetMonitors(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -1142,6 +1183,7 @@ class SetMonitor(rq.Request):
 
 
 def set_monitor(self, monitor_info):
+    # type: (drawable.Window, tuple[int, bool, bool, Sequence[int], int, int, int, int, int]) -> SetMonitor
     return SetMonitor(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -1161,6 +1203,7 @@ class DeleteMonitor(rq.Request):
 
 
 def delete_monitor(self, name):
+    # type: (Display | resource.Resource, str) -> DeleteMonitor
     return DeleteMonitor(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -1242,6 +1285,7 @@ class OutputPropertyNotify(rq.Event):
 # Initialization #
 
 def init(disp, info):
+    # type: (Display, request.QueryExtension) -> None
     disp.extension_add_method('display', 'xrandr_query_version', query_version)
     disp.extension_add_method('window', 'xrandr_select_input', select_input)
     disp.extension_add_method('window', 'xrandr_get_screen_info', get_screen_info)

--- a/Xlib/ext/record.py
+++ b/Xlib/ext/record.py
@@ -21,6 +21,17 @@
 
 from Xlib import X
 from Xlib.protocol import rq
+try:
+    from typing import TYPE_CHECKING, Any, TypeVar
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from Xlib.display import Display
+    from Xlib.protocol import display
+    from collections.abc import Sequence, Sized, Callable
+    from Xlib.xobject import  resource
+    _T = TypeVar("_T")
+    _S = TypeVar("_S", bound=Sized)
 
 extname = 'RECORD'
 
@@ -73,9 +84,11 @@ class RawField(rq.ValueField):
     structcode = None
 
     def pack_value(self, val):
+        # type: (_S) -> tuple[_S, int, None]
         return val, len(val), None
 
     def parse_binary_value(self, data, display, length, format):
+        # type: (_T, object, object, object) -> tuple[_T, bytes]
         return data, ''
 
 
@@ -95,6 +108,7 @@ class GetVersion(rq.ReplyRequest):
             rq.Pad(20))
 
 def get_version(self, major, minor):
+    # type: (Display | resource.Resource, int, int) -> GetVersion
     return GetVersion(
             display = self.display,
             opcode = self.display.get_extension_major(extname),
@@ -116,6 +130,7 @@ class CreateContext(rq.Request):
             rq.List('ranges', Record_Range))
 
 def create_context(self, datum_flags, clients, ranges):
+    # type: (Display | resource.Resource, int, Sequence[int], Sequence[tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], bool, bool]]) -> int
     context = self.display.allocate_resource_id()
     CreateContext(
             display = self.display,
@@ -141,6 +156,7 @@ class RegisterClients(rq.Request):
             rq.List('ranges', Record_Range))
 
 def register_clients(self, context, element_header, clients, ranges):
+    # type: (Display | resource.Resource, int, int, Sequence[int], Sequence[tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], bool, bool]]) -> None
     RegisterClients(
             display = self.display,
             opcode = self.display.get_extension_major(extname),
@@ -160,6 +176,7 @@ class UnregisterClients(rq.Request):
             rq.List('clients', rq.Card32Obj))
 
 def unregister_clients(self, context, clients):
+    # type: (Display | resource.Resource, int, Sequence[int]) -> None
     UnregisterClients(
             display = self.display,
             opcode = self.display.get_extension_major(extname),
@@ -184,6 +201,7 @@ class GetContext(rq.ReplyRequest):
             rq.List('client_info', Record_ClientInfo))
 
 def get_context(self, context):
+    # type: (Display | resource.Resource, int) -> GetContext
     return GetContext(
             display = self.display,
             opcode = self.display.get_extension_major(extname),
@@ -216,6 +234,7 @@ class EnableContext(rq.ReplyRequest):
     # See the discussion on ListFonstsWithInfo in request.py
 
     def __init__(self, callback, *args, **keys):
+        # type: (Callable[[rq.DictWrapper | dict[str, object]], Any], display.Display, object, bool, object) -> None
         self._callback = callback
         rq.ReplyRequest.__init__(self, *args, **keys)
 
@@ -236,6 +255,7 @@ class EnableContext(rq.ReplyRequest):
             self._display.sent_requests.insert(0, self)
 
 def enable_context(self, context, callback):
+    # type: (Display | resource.Resource, int, Callable[[rq.DictWrapper | dict[str, object]], Any]) -> None
     EnableContext(
             callback = callback,
             display = self.display,
@@ -251,6 +271,7 @@ class DisableContext(rq.Request):
             rq.Card32('context'))           # Record_RC
 
 def disable_context(self, context):
+    # type: (Display | resource.Resource, int) -> None
     DisableContext(
             display = self.display,
             opcode = self.display.get_extension_major(extname),
@@ -265,6 +286,7 @@ class FreeContext(rq.Request):
             rq.Card32('context'))           # Record_RC
 
 def free_context(self, context):
+    # type: (Display | resource.Resource, int) -> None
     FreeContext(
             display = self.display,
             opcode = self.display.get_extension_major(extname),
@@ -273,6 +295,7 @@ def free_context(self, context):
 
 
 def init(disp, info):
+    # type: (Display, object) -> None
     disp.extension_add_method('display', 'record_get_version', get_version)
     disp.extension_add_method('display', 'record_create_context', create_context)
     disp.extension_add_method('display', 'record_register_clients', register_clients)

--- a/Xlib/ext/res.py
+++ b/Xlib/ext/res.py
@@ -29,6 +29,14 @@ XCB Protocol specification:
     https://cgit.freedesktop.org/xcb/proto/tree/src/res.xml
 """
 from Xlib.protocol import rq
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from Xlib.display import Display
+    from Xlib.xobject import resource
+    from collections.abc import Sequence
 
 RES_MAJOR_VERSION = 1
 RES_MINOR_VERSION = 2
@@ -65,6 +73,7 @@ class QueryVersion(rq.ReplyRequest):
 
 def query_version(self, client_major=RES_MAJOR_VERSION,
                   client_minor=RES_MINOR_VERSION):
+    # type: (Display | resource.Resource, int, int) -> QueryVersion
     """ Query the protocol version supported by the X server.
 
     The client sends the highest supported version to the server and the
@@ -98,6 +107,7 @@ class QueryClients(rq.ReplyRequest):
 
 
 def query_clients(self):
+    # type: (Display | resource.Resource) -> QueryClients
     """Request the list of all currently connected clients."""
     return QueryClients(
             display=self.display,
@@ -126,6 +136,7 @@ class QueryClientResources(rq.ReplyRequest):
 
 
 def query_client_resources(self, client):
+    # type: (Display | resource.Resource, int) -> QueryClientResources
     """Request the number of resources owned by a client.
 
     The server will return the counts of each type of resource.
@@ -153,6 +164,7 @@ class QueryClientPixmapBytes(rq.ReplyRequest):
 
 
 def query_client_pixmap_bytes(self, client):
+    # type: (Display | resource.Resource, int) -> QueryClientPixmapBytes
     """Query the pixmap usage of some client.
 
     The returned number is a sum of memory usage of each pixmap that can be
@@ -169,10 +181,12 @@ class SizeOf(rq.LengthOf):
     may vary, e.g. List
     """
     def __init__(self, name, size, item_size):
+        # type: (str | list[str] | tuple[str, ...], int, int) -> None
         rq.LengthOf.__init__(self, name, size)
         self.item_size = item_size
 
     def parse_value(self, length, display):
+        # type: (int, object) -> int
         return length // self.item_size
 
 
@@ -209,6 +223,7 @@ class QueryClientIds(rq.ReplyRequest):
 
 
 def query_client_ids(self, specs):
+    # type: (Display | resource.Resource, Sequence[tuple[int, int]]) -> QueryClientIds
     """Request to identify a given set of clients with some identification method.
 
     The request sends a list of specifiers that select clients and
@@ -262,6 +277,7 @@ class QueryResourceBytes(rq.ReplyRequest):
 
 
 def query_resource_bytes(self, client, specs):
+    # type: (Display | resource.Resource, int, Sequence[tuple[int, int]]) -> QueryResourceBytes
     """Query the sizes of resources from X server.
 
     The request sends a list of specifiers that selects resources for size
@@ -276,6 +292,7 @@ def query_resource_bytes(self, client, specs):
 
 
 def init(disp, info):
+    # type: (Display, object) -> None
     disp.extension_add_method("display", "res_query_version", query_version)
     disp.extension_add_method("display", "res_query_clients", query_clients)
     disp.extension_add_method("display", "res_query_client_resources",

--- a/Xlib/ext/screensaver.py
+++ b/Xlib/ext/screensaver.py
@@ -33,6 +33,20 @@ XCB Protocol specification:
 from Xlib import X
 from Xlib.protocol import rq, structs
 
+try:
+    from typing import TYPE_CHECKING, TypeVar, Optional
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import TypeAlias
+    from Xlib.error import XError
+    from Xlib.protocol import request
+    from Xlib.display import Display
+    from Xlib.xobject import drawable, resource
+    _T = TypeVar("_T")
+    _ErrorHandler:  TypeAlias = Callable[[XError, Optional[rq.Request]], _T]
+
 extname = 'MIT-SCREEN-SAVER'
 
 # Event members
@@ -70,6 +84,7 @@ class QueryVersion(rq.ReplyRequest):
             )
 
 def query_version(self):
+    # type: (Display | resource.Resource) -> QueryVersion
     return QueryVersion(display=self.display,
                         opcode=self.display.get_extension_major(extname),
                         major_version=1,
@@ -98,6 +113,7 @@ class QueryInfo(rq.ReplyRequest):
             )
 
 def query_info(self):
+    # type: (drawable.Drawable) -> QueryInfo
     return QueryInfo(display=self.display,
                      opcode=self.display.get_extension_major(extname),
                      drawable=self,
@@ -114,6 +130,7 @@ class SelectInput(rq.Request):
         )
 
 def select_input(self, mask):
+    # type: (drawable.Drawable, int) -> SelectInput
     return SelectInput(display=self.display,
                        opcode=self.display.get_extension_major(extname),
                        drawable=self,
@@ -144,6 +161,7 @@ def set_attributes(self, x, y, width, height, border_width,
                    visual = X.CopyFromParent,
                    onerror = None,
                    **keys):
+    # type: (drawable.Drawable, int, int, int, int, int, int, int, int, _ErrorHandler[object] | None, object) -> SetAttributes
     return SetAttributes(display=self.display,
                          onerror = onerror,
                          opcode=self.display.get_extension_major(extname),
@@ -168,6 +186,7 @@ class UnsetAttributes(rq.Request):
         )
 
 def unset_attributes(self, onerror = None):
+    # type: (drawable.Drawable, _ErrorHandler[object] | None) -> UnsetAttributes
     return UnsetAttributes(display=self.display,
                            onerror = onerror,
                            opcode=self.display.get_extension_major(extname),
@@ -189,6 +208,7 @@ class Notify(rq.Event):
         )
 
 def init(disp, info):
+    # type: (Display, request.QueryExtension) -> None
     disp.extension_add_method('display', 'screensaver_query_version', query_version)
     disp.extension_add_method('drawable', 'screensaver_query_info', query_info)
     disp.extension_add_method('drawable', 'screensaver_select_input', select_input)

--- a/Xlib/ext/security.py
+++ b/Xlib/ext/security.py
@@ -26,6 +26,17 @@ SecurityAuthorizationRevoked event is not implemented.
 '''
 
 from Xlib.protocol import rq
+try:
+    from typing import TYPE_CHECKING, Any, Union
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from mmap import mmap
+    from typing_extensions import TypeAlias
+    from Xlib.display import Display
+    from Xlib.xobject import resource
+    from array import array
+    _SliceableBuffer: TypeAlias = Union[bytes, bytearray, memoryview, array[Any], mmap]
 
 
 extname = 'SECURITY'
@@ -58,6 +69,7 @@ class QueryVersion(rq.ReplyRequest):
 
 
 def query_version(self):
+    # type: (Display | resource.Resource) -> QueryVersion
     return QueryVersion(display=self.display,
                         opcode=self.display.get_extension_major(extname),
                         major_version=1,
@@ -91,6 +103,7 @@ class SecurityGenerateAuthorization(rq.ReplyRequest):
 
 def generate_authorization(self, auth_proto, auth_data=b'', timeout=None,
                            trust_level=None, group=None, event_mask=None):
+    # type: (Display | resource.Resource, str, _SliceableBuffer, int | None, int | None, int | None, int | None) -> SecurityGenerateAuthorization
     value_mask = 0
     values = []
     if timeout is not None:
@@ -122,12 +135,14 @@ class SecurityRevokeAuthorization(rq.Request):
 
 
 def revoke_authorization(self, authid):
+    # type: (Display | resource.Resource, int) -> SecurityRevokeAuthorization
     return SecurityRevokeAuthorization(display=self.display,
                                        opcode=self.display.get_extension_major(extname),
                                        authid=authid)
 
 
 def init(disp, info):
+    # type: (Display, object) -> None
     disp.extension_add_method('display',
                               'security_query_version',
                               query_version)

--- a/Xlib/ext/shape.py
+++ b/Xlib/ext/shape.py
@@ -2,6 +2,15 @@
 # Generated from: /usr/share/xcb/shape.xml
 
 from Xlib.protocol import rq, structs
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from Xlib.display import Display
+    from Xlib.protocol import request
+    from Xlib.xobject import resource, drawable
+    from collections.abc import Sequence
 
 
 extname = 'SHAPE'
@@ -23,6 +32,7 @@ class SK:
 class KIND(rq.Set):
 
     def __init__(self, name):
+        # type: (str) -> None
         super(KIND, self).__init__(name, 1,
                                    values=(SK.Bounding,
                                            SK.Clip,
@@ -201,6 +211,7 @@ class Event:
     Notify = 0
 
 def combine(self, operation, destination_kind, source_kind, x_offset, y_offset):
+    # type: (drawable.Window, int, int, int, int, int) -> None
     Combine(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -213,6 +224,7 @@ def combine(self, operation, destination_kind, source_kind, x_offset, y_offset):
     )
 
 def get_rectangles(self, source_kind):
+    # type: (drawable.Window, int) -> GetRectangles
     return GetRectangles(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -221,6 +233,7 @@ def get_rectangles(self, source_kind):
     )
 
 def input_selected(self, ):
+    # type: (drawable.Window) -> InputSelected
     return InputSelected(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -228,6 +241,7 @@ def input_selected(self, ):
     )
 
 def mask(self, operation, destination_kind, x_offset, y_offset, source_bitmap):
+    # type: (drawable.Window, int, int, int, int, int) -> None
     Mask(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -240,6 +254,7 @@ def mask(self, operation, destination_kind, x_offset, y_offset, source_bitmap):
     )
 
 def offset(self, destination_kind, x_offset, y_offset):
+    # type: (drawable.Window, int, int, int) -> None
     Offset(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -250,6 +265,7 @@ def offset(self, destination_kind, x_offset, y_offset):
     )
 
 def query_extents(self, ):
+    # type: (drawable.Window) -> QueryExtents
     return QueryExtents(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -257,12 +273,14 @@ def query_extents(self, ):
     )
 
 def query_version(self, ):
+    # type: (Display | resource.Resource) -> QueryVersion
     return QueryVersion(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
     )
 
 def rectangles(self, operation, destination_kind, ordering, x_offset, y_offset, rectangles):
+    # type: (drawable.Window, int, int, int, int, int, Sequence[tuple[int, int, int, int]]) -> None
     Rectangles(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -276,6 +294,7 @@ def rectangles(self, operation, destination_kind, ordering, x_offset, y_offset, 
     )
 
 def select_input(self, enable):
+    # type: (drawable.Window, int) -> None
     SelectInput(
         display=self.display,
         opcode=self.display.get_extension_major(extname),
@@ -284,6 +303,7 @@ def select_input(self, enable):
     )
 
 def init(disp, info):
+    # type: (Display, request.QueryExtension) -> None
     disp.extension_add_method('window', 'shape_combine', combine)
     disp.extension_add_method('window', 'shape_get_rectangles', get_rectangles)
     disp.extension_add_method('window', 'shape_input_selected', input_selected)

--- a/Xlib/ext/xfixes.py
+++ b/Xlib/ext/xfixes.py
@@ -26,7 +26,9 @@ ShowCursor requests and SelectionNotify events are provided.
 '''
 
 from Xlib import X
-from Xlib.protocol import rq, structs
+from Xlib.protocol import rq, request
+from Xlib.display import Display
+from Xlib.xobject import resource, drawable
 
 extname = 'XFIXES'
 
@@ -61,6 +63,7 @@ class QueryVersion(rq.ReplyRequest):
 
 
 def query_version(self):
+    # type: (Display | resource.Resource) -> QueryVersion
     return QueryVersion(display=self.display,
                         opcode=self.display.get_extension_major(extname),
                         major_version=4,
@@ -75,6 +78,7 @@ class HideCursor(rq.Request):
                          )
 
 def hide_cursor(self):
+    # type: (drawable.Window) -> None
     HideCursor(display=self.display,
                opcode=self.display.get_extension_major(extname),
                window=self)
@@ -89,6 +93,7 @@ class ShowCursor(rq.Request):
 
 
 def show_cursor(self):
+    # type: (drawable.Window) -> None
     ShowCursor(display=self.display,
                opcode=self.display.get_extension_major(extname),
                window=self)
@@ -103,6 +108,7 @@ class SelectSelectionInput(rq.Request):
                          )
 
 def select_selection_input(self, window, selection, mask):
+    # type: (Display | resource.Resource, int, int, int) -> SelectSelectionInput
     return SelectSelectionInput(opcode=self.display.get_extension_major(extname),
                                 display=self.display,
                                 window=window,
@@ -144,6 +150,7 @@ class SelectCursorInput(rq.Request):
                          )
 
 def select_cursor_input(self, window, mask):
+    # type: (Display | resource.Resource, int, int) -> SelectCursorInput
     return SelectCursorInput(opcode=self.display.get_extension_major(extname),
                              display=self.display,
                              window=window,
@@ -172,6 +179,7 @@ class GetCursorImage(rq.ReplyRequest):
                        )
 
 def get_cursor_image(self, window):
+    # type: (Display | resource.Resource, object) -> GetCursorImage
     return GetCursorImage(opcode=self.display.get_extension_major(extname),
                           display=self.display,
                          )
@@ -188,6 +196,7 @@ class DisplayCursorNotify(rq.Event):
 
 
 def init(disp, info):
+    # type: (Display, request.QueryExtension) -> None
     disp.extension_add_method('display', 'xfixes_select_selection_input', select_selection_input)
     disp.extension_add_method('display', 'xfixes_query_version', query_version)
     disp.extension_add_method('window', 'xfixes_hide_cursor', hide_cursor)

--- a/Xlib/ext/xinerama.py
+++ b/Xlib/ext/xinerama.py
@@ -37,6 +37,8 @@ returns the state information - because that's what libXinerama does."""
 
 from Xlib import X
 from Xlib.protocol import rq, structs
+from Xlib.display import Display
+from Xlib.xobject import resource, drawable
 
 extname = 'XINERAMA'
 
@@ -62,6 +64,7 @@ class QueryVersion(rq.ReplyRequest):
             )
 
 def query_version(self):
+    # type: (Display | resource.Resource) -> QueryVersion
     return QueryVersion(display=self.display,
                         opcode=self.display.get_extension_major(extname),
                         major_version=1,
@@ -85,6 +88,7 @@ class GetState(rq.ReplyRequest):
         )
 
 def get_state(self):
+    # type: (drawable.Window) -> GetState
     return GetState(display=self.display,
                     opcode=self.display.get_extension_major(extname),
                     window=self.id,
@@ -108,6 +112,7 @@ class GetScreenCount(rq.ReplyRequest):
         )
 
 def get_screen_count(self):
+    # type: (drawable.Window) -> GetScreenCount
     return GetScreenCount(display=self.display,
                           opcode=self.display.get_extension_major(extname),
                           window=self.id,
@@ -135,6 +140,7 @@ class GetScreenSize(rq.ReplyRequest):
         )
 
 def get_screen_size(self, screen_no):
+    # type: (drawable.Window, int) -> GetScreenSize
     """Returns the size of the given screen number"""
     return GetScreenSize(display=self.display,
                          opcode=self.display.get_extension_major(extname),
@@ -161,6 +167,7 @@ class IsActive(rq.ReplyRequest):
         )
 
 def is_active(self):
+    # type: (Display | resource.Resource) -> int
     r = IsActive(display=self.display,
                  opcode=self.display.get_extension_major(extname),
                  )
@@ -185,6 +192,7 @@ class QueryScreens(rq.ReplyRequest):
         )
 
 def query_screens(self):
+    # type: (Display | resource.Resource) -> QueryScreens
     # Hmm. This one needs to read the screen data from the socket. Ooops...
     return QueryScreens(display=self.display,
                         opcode=self.display.get_extension_major(extname),
@@ -209,11 +217,13 @@ class GetInfo(rq.ReplyRequest):
         )
 
 def get_info(self, visual):
+    # type: (Display | resource.Resource, int) -> None
     r = GetInfo(display=self.display,
              opcode=self.display.get_extension_major(extname),
              visual=visual)
 
 def init(disp, info):
+    # type: (Display, object) -> None
     disp.extension_add_method('display', 'xinerama_query_version', query_version)
     disp.extension_add_method('window', 'xinerama_get_state', get_state)
     disp.extension_add_method('window', 'xinerama_get_screen_count', get_screen_count)

--- a/Xlib/ext/xtest.py
+++ b/Xlib/ext/xtest.py
@@ -21,6 +21,8 @@
 
 from Xlib import X
 from Xlib.protocol import rq
+from Xlib.display import Display
+from Xlib.xobject import resource
 
 extname = 'XTEST'
 
@@ -44,6 +46,7 @@ class GetVersion(rq.ReplyRequest):
                        )
 
 def get_version(self, major, minor):
+    # type: (Display | resource.Resource, int, int) -> GetVersion
     return GetVersion(display = self.display,
                       opcode = self.display.get_extension_major(extname),
                       major_version = major,
@@ -65,6 +68,7 @@ class CompareCursor(rq.ReplyRequest):
                        )
 
 def compare_cursor(self, cursor):
+    # type: (Display | resource.Resource, int) -> int
     r = CompareCursor(display = self.display,
                       opcode = self.display.get_extension_major(extname),
                       window = self.id,
@@ -92,6 +96,7 @@ class FakeInput(rq.Request):
 
 def fake_input(self, event_type, detail = 0, time = X.CurrentTime,
                root = X.NONE, x = 0, y = 0):
+    # type: (Display | resource.Resource, int, int, int, int, int, int) -> None
 
     FakeInput(display = self.display,
               opcode = self.display.get_extension_major(extname),
@@ -111,11 +116,13 @@ class GrabControl(rq.Request):
                          )
 
 def grab_control(self, impervious):
+    # type: (Display | resource.Resource, bool) -> None
     GrabControl(display = self.display,
                 opcode = self.display.get_extension_major(extname),
                 impervious = impervious)
 
 def init(disp, info):
+    # type: (Display, object) -> None
     disp.extension_add_method('display', 'xtest_get_version', get_version)
     disp.extension_add_method('window', 'xtest_compare_cursor', compare_cursor)
     disp.extension_add_method('display', 'xtest_fake_input', fake_input)

--- a/Xlib/protocol/request.py
+++ b/Xlib/protocol/request.py
@@ -26,6 +26,7 @@ from .. import X
 # Xlib.protocol modules
 from . import rq
 from . import structs
+from . import display
 
 
 class CreateWindow(rq.Request):
@@ -786,6 +787,7 @@ class ListFontsWithInfo(rq.ReplyRequest):
     # Bastards.
 
     def __init__(self, *args, **keys):
+        # type: (display.Display, bool, object, object) -> None
         self._fonts = []
         rq.ReplyRequest.__init__(self, *args, **keys)
 

--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -1109,7 +1109,7 @@ class Struct(object):
 
         for f in self.var_fields:
             if f.keyword_args:
-                v, l, fm = f.pack_value(field_args[f.name], keys)
+                v, l, fm = f.pack_value(field_args[f.name], keys)  # ValueList
             else:
                 v, l, fm = f.pack_value(field_args[f.name])
             var_vals[f.name] = v
@@ -1473,7 +1473,7 @@ class Request(object):
         # type: (_BaseDisplay, _ErrorHandler[object] | None, object, object) -> None
         self._errorhandler = onerror
         self._binary = self._request.to_binary(*args, **keys)
-        self._serial = None
+        self._serial = None  # type: int | None
         display.send_request(self, onerror is not None)
 
     def _set_error(self, error):

--- a/Xlib/protocol/structs.py
+++ b/Xlib/protocol/structs.py
@@ -25,7 +25,11 @@ from .. import X
 # Xlib.protocol modules
 from . import rq
 
+# TODO: Complete all classes using WindowValues and GCValues
+# Currently *object is used to represent the ValueList instead of the possible attribute types
+
 def WindowValues(arg):
+    # type: (str) -> rq.ValueList
     return rq.ValueList( arg, 4, 0,
                          rq.Pixmap('background_pixmap'),
                          rq.Card32('background_pixel'),
@@ -46,6 +50,7 @@ def WindowValues(arg):
                          )
 
 def GCValues(arg):
+    # type: (str) -> rq.ValueList
     return rq.ValueList( arg, 4, 0,
                          rq.Set('function', 1,
                                 (X.GXclear, X.GXand, X.GXandReverse,

--- a/Xlib/py.typed
+++ b/Xlib/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The Xlib package uses inline types.

--- a/Xlib/rdb.py
+++ b/Xlib/rdb.py
@@ -22,7 +22,7 @@
 
 # See end of file for an explanation of the algorithm and
 # data structures used.
-
+from __future__ import annotations
 
 # Standard modules
 import re
@@ -30,6 +30,24 @@ import sys
 
 # Xlib modules
 from .support import lock
+
+try:
+    from typing import TYPE_CHECKING, Any, TypeVar, Protocol, overload
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from _typeshed import SupportsRead, SupportsDunderLT, SupportsDunderGT
+    class SupportsDunderEQ(Protocol):
+        def __eq__(self, __other: object) -> bool: ...
+    class SupportsComparisons(
+        SupportsDunderLT[object], SupportsDunderGT[object], SupportsDunderEQ, Protocol
+    ): ...
+    from typing_extensions import TypeAlias
+    from Xlib import display
+    _T = TypeVar("_T")
+    _C = TypeVar("_C", bound=SupportsComparisons)
+    _DB: TypeAlias = dict[str, tuple["_DB", ...]]
 
 # Set up a few regexpes for parsing string representation of resources
 
@@ -52,7 +70,8 @@ class OptionError(Exception):
 
 class ResourceDB(object):
     def __init__(self, file = None, string = None, resources = None):
-        self.db = {}
+        # type: (bytes | SupportsRead[str] | None, str | None, Iterable[tuple[str, object]] | None) -> None
+        self.db = {}  # type: _DB
         self.lock = lock.allocate_lock()
 
         if file is not None:
@@ -63,6 +82,7 @@ class ResourceDB(object):
             self.insert_resources(resources)
 
     def insert_file(self, file):
+        # type: (bytes | SupportsRead[str]) -> None
         """insert_file(file)
 
         Load resources entries from FILE, and insert them into the
@@ -77,6 +97,7 @@ class ResourceDB(object):
 
 
     def insert_string(self, data):
+        # type: (str) -> None
         """insert_string(data)
 
         Insert the resources entries in the string DATA into the
@@ -137,6 +158,7 @@ class ResourceDB(object):
 
 
     def insert_resources(self, resources):
+        # type: (Iterable[tuple[str, object]]) -> None
         """insert_resources(resources)
 
         Insert all resources entries in the list RESOURCES into the
@@ -152,6 +174,7 @@ class ResourceDB(object):
             self.insert(res, value)
 
     def insert(self, resource, value):
+        # type: (str, object) -> None
         """insert(resource, value)
 
         Insert a resource entry into the database.  RESOURCE is a
@@ -191,6 +214,7 @@ class ResourceDB(object):
         self.lock.release()
 
     def __getitem__(self, keys_tuple):
+        # type: (tuple[str, str]) -> Any
         """db[name, class]
 
         Return the value matching the resource identified by NAME and
@@ -303,7 +327,14 @@ class ResourceDB(object):
         finally:
             self.lock.release()
 
+    if TYPE_CHECKING:
+        @overload
+        def get(self, res: str, cls: str, default: None = ...) -> Any: ...
+        @overload
+        def get(self, res: str, cls: str, default: _T) -> _T: ...
+
     def get(self, res, cls, default = None):
+        # type: (str, str, object) -> Any
         """get(name, class [, default])
 
         Return the value matching the resource identified by NAME and
@@ -318,6 +349,7 @@ class ResourceDB(object):
             return default
 
     def update(self, db):
+        # type: (ResourceDB) -> None
         """update(db)
 
         Update this database with all resources entries in the resource
@@ -341,6 +373,7 @@ class ResourceDB(object):
         return text
 
     def getopt(self, name, argv, opts):
+        # type: (str, Sequence[str], dict[str, Option]) -> Sequence[str]
         """getopt(name, argv, opts)
 
         Parse X command line options, inserting the recognised options
@@ -452,6 +485,7 @@ class _Match(object):
 #
 
 def bin_insert(list, element):
+    # type: (list[_C], _C) -> None
     """bin_insert(list, element)
 
     Insert ELEMENT into LIST.  LIST must be sorted, and ELEMENT will
@@ -487,6 +521,7 @@ def bin_insert(list, element):
 #
 
 def update_db(dest, src):
+    # type: (_DB, _DB) -> None
     for comp, group in src.items():
 
         # DEST already contains this component, update it
@@ -507,9 +542,11 @@ def update_db(dest, src):
             dest[comp] = copy_group(group)
 
 def copy_group(group):
+    # type: (tuple[_DB, ...]) -> tuple[_DB, ...]
     return (copy_db(group[0]), copy_db(group[1])) + group[2:]
 
 def copy_db(db):
+    # type: (_DB) -> _DB
     newdb = {}
     for comp, group in db.items():
         newdb[comp] = copy_group(group)
@@ -522,6 +559,7 @@ def copy_db(db):
 #
 
 def output_db(prefix, db):
+    # type: (str, _DB) -> str
     res = ''
     for comp, group in db.items():
 
@@ -536,6 +574,7 @@ def output_db(prefix, db):
     return res
 
 def output_escape(value):
+    # type: (object) -> str
     value = str(value)
     if not value:
         return value
@@ -564,39 +603,47 @@ class Option(object):
         pass
 
     def parse(self, name, db, args):
+        # type: (str, ResourceDB, Sequence[_T]) -> Sequence[_T]
         pass
 
 class NoArg(Option):
     """Value is provided to constructor."""
     def __init__(self, specifier, value):
+        # type: (str, object) -> None
         self.specifier = specifier
         self.value = value
 
     def parse(self, name, db, args):
+        # type: (str, ResourceDB, Sequence[_T]) -> Sequence[_T]
         db.insert(name + self.specifier, self.value)
         return args[1:]
 
 class IsArg(Option):
     """Value is the option string itself."""
     def __init__(self, specifier):
+        # type: (str) -> None
         self.specifier = specifier
 
     def parse(self, name, db, args):
+        # type: (str, ResourceDB, Sequence[_T]) -> Sequence[_T]
         db.insert(name + self.specifier, args[0])
         return args[1:]
 
 class SepArg(Option):
     """Value is the next argument."""
     def __init__(self, specifier):
+        # type: (str) -> None
         self.specifier = specifier
 
     def parse(self, name, db, args):
+        # type: (str, ResourceDB, Sequence[_T]) -> Sequence[_T]
         db.insert(name + self.specifier, args[1])
         return args[2:]
 
 class ResArgClass(Option):
     """Resource and value in the next argument."""
     def parse(self, name, db, args):
+        # type: (str, ResourceDB, Sequence[str]) -> Sequence[str]
         db.insert_string(args[1])
         return args[2:]
 
@@ -605,6 +652,7 @@ ResArg = ResArgClass()
 class SkipArgClass(Option):
     """Ignore this option and next argument."""
     def parse(self, name, db, args):
+        # type: (str, ResourceDB, Sequence[_T]) -> Sequence[_T]
         return args[2:]
 
 SkipArg = SkipArgClass()
@@ -612,6 +660,7 @@ SkipArg = SkipArgClass()
 class SkipLineClass(Option):
     """Ignore rest of the arguments."""
     def parse(self, name, db, args):
+        # type: (str, ResourceDB, Sequence[_T]) -> Sequence[_T]
         return []
 
 SkipLine = SkipLineClass()
@@ -619,14 +668,17 @@ SkipLine = SkipLineClass()
 class SkipNArgs(Option):
     """Ignore this option and the next COUNT arguments."""
     def __init__(self, count):
+        # type: (int) -> None
         self.count = count
 
     def parse(self, name, db, args):
+        # type: (str, ResourceDB, Sequence[_T]) -> Sequence[_T]
         return args[1 + self.count:]
 
 
 
 def get_display_opts(options, argv = sys.argv):
+    # type: (dict[str, Option], Sequence[str]) -> tuple[display.Display, str, ResourceDB, Sequence[str]]
     """display, name, db, args = get_display_opts(options, [argv])
 
     Parse X OPTIONS from ARGV (or sys.argv if not provided).

--- a/Xlib/support/connect.py
+++ b/Xlib/support/connect.py
@@ -18,9 +18,20 @@
 #    59 Temple Place,
 #    Suite 330,
 #    Boston, MA 02111-1307 USA
+from __future__ import annotations
 
 import sys
 import importlib
+
+try:
+    from typing import TYPE_CHECKING, Any, Union
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import socket
+    from typing_extensions import TypeAlias
+    from Xlib.support.unix_connect import _Protocol
+    _Address: TypeAlias = Union[tuple[Any, ...], str]
 
 # List the modules which contain the corresponding functions
 
@@ -54,8 +65,14 @@ del _parts
 def _relative_import(modname):
     return importlib.import_module('..' + modname, __name__)
 
+if TYPE_CHECKING:
+    if sys.platform == 'OpenVMS':
+        from Xlib.support.vms_connect import get_display as get_display, get_socket as get_socket
+    else:
+        from Xlib.support.unix_connect import get_display as get_display, get_socket as get_socket
 
 def get_display(display):
+    # type: (str | None) -> tuple[str, str | None, str | None, int, int]
     """dname, protocol, host, dno, screen = get_display(display)
 
     Parse DISPLAY into its components.  If DISPLAY is None, use
@@ -72,8 +89,8 @@ def get_display(display):
     mod = _relative_import(modname)
     return mod.get_display(display)
 
-
 def get_socket(dname, protocol, host, dno):
+    # type: (_Address, _Protocol, _Address | None, int) -> socket.socket
     """socket = get_socket(dname, protocol, host, dno)
 
     Connect to the display specified by DNAME, PROTOCOL, HOST and DNO, which
@@ -88,6 +105,7 @@ def get_socket(dname, protocol, host, dno):
 
 
 def get_auth(sock, dname, protocol, host, dno):
+    # type: (socket.socket, object, _Protocol, object, int) -> tuple[bytes, bytes]
     """auth_name, auth_data = get_auth(sock, dname, protocol, host, dno)
 
     Return authentication data for the display on the other side of

--- a/Xlib/support/lock.py
+++ b/Xlib/support/lock.py
@@ -34,6 +34,7 @@ class _DummyLock(object):
         self.acquire = self.release = self.locked = self.__noop
 
     def __noop(self, *args):
+        # type: (object) -> None
         return
 
 

--- a/Xlib/support/vms_connect.py
+++ b/Xlib/support/vms_connect.py
@@ -24,10 +24,18 @@ import socket
 
 from Xlib import error
 
+try:
+    from typing import TYPE_CHECKING, Any, Union
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+    _Address: TypeAlias = Union[tuple[Any, ...], str]
+
 display_re = re.compile(r'^([-a-zA-Z0-9._]*):([0-9]+)(\.([0-9]+))?$')
 
 def get_display(display):
-
+    # type: (str | None) -> tuple[str, None, str, int, int]
     # Use dummy display if none is set.  We really should
     # check DECW$DISPLAY instead, but that has to wait
 
@@ -56,6 +64,7 @@ def get_display(display):
 
 
 def get_socket(dname, protocol, host, dno):
+    # type: (_Address, object, _Address, int) -> socket.socket
     try:
         # Always use TCP/IP sockets.  Later it would be nice to
         # be able to use DECNET och LOCAL connections.
@@ -70,5 +79,6 @@ def get_socket(dname, protocol, host, dno):
 
 
 def get_auth(sock, dname, host, dno):
+    # type: (object, object, object, object) -> tuple[str, str]
     # VMS doesn't have xauth
     return '', ''

--- a/Xlib/xauth.py
+++ b/Xlib/xauth.py
@@ -18,6 +18,7 @@
 #    59 Temple Place,
 #    Suite 330,
 #    Boston, MA 02111-1307 USA
+from __future__ import annotations
 
 import os
 import struct
@@ -33,6 +34,7 @@ FamilyLocal = 256
 
 class Xauthority(object):
     def __init__(self, filename = None):
+        # type: (str | bytes | os.PathLike[str] | os.PathLike[bytes] | int | None) -> None
         if filename is None:
             filename = os.environ.get('XAUTHORITY')
 
@@ -49,7 +51,7 @@ class Xauthority(object):
         except IOError as err:
             raise error.XauthError('could not read from {0}: {1}'.format(filename, err))
 
-        self.entries = []
+        self.entries = []  # type: list[tuple[bytes, bytes, bytes, bytes, bytes]]
 
         # entry format (all shorts in big-endian)
         #   short family;
@@ -99,11 +101,12 @@ class Xauthority(object):
         return len(self.entries)
 
     def __getitem__(self, i):
+        # type: (int) -> tuple[bytes, bytes, bytes, bytes, bytes]
         return self.entries[i]
 
     def get_best_auth(self, family, address, dispno,
                       types = ( b"MIT-MAGIC-COOKIE-1", )):
-
+        # type: (bytes, bytes, bytes, tuple[bytes]) -> tuple[bytes, bytes]
         """Find an authentication entry matching FAMILY, ADDRESS and
         DISPNO.
 

--- a/Xlib/xobject/colormap.py
+++ b/Xlib/xobject/colormap.py
@@ -26,6 +26,18 @@ from . import resource
 
 import re
 
+try:
+    from typing import TYPE_CHECKING, TypeVar, Optional
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from typing_extensions import TypeAlias
+    from Xlib.protocol import rq
+
+    _T = TypeVar("_T")
+    _ErrorHandler:  TypeAlias = Callable[[error.XError, Optional[rq.Request]], _T]
+
 rgb_res = [
     re.compile(r'\Argb:([0-9a-fA-F]{1,4})/([0-9a-fA-F]{1,4})/([0-9a-fA-F]{1,4})\Z'),
     re.compile(r'\A#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])\Z'),
@@ -38,6 +50,7 @@ class Colormap(resource.Resource):
     __colormap__ = resource.Resource.__resource__
 
     def free(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.FreeColormap(display = self.display,
                              onerror = onerror,
                              cmap = self.id)
@@ -45,6 +58,7 @@ class Colormap(resource.Resource):
         self.display.free_resource_id(self.id)
 
     def copy_colormap_and_free(self, scr_cmap):
+        # type: (int) -> Colormap
         mid = self.display.allocate_resource_id()
         request.CopyColormapAndFree(display = self.display,
                                     mid = mid,
@@ -54,11 +68,13 @@ class Colormap(resource.Resource):
         return cls(self.display, mid, owner = 1)
 
     def install_colormap(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.InstallColormap(display = self.display,
                                 onerror = onerror,
                                 cmap = self.id)
 
     def uninstall_colormap(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.UninstallColormap(display = self.display,
                                   onerror = onerror,
                                   cmap = self.id)
@@ -71,6 +87,7 @@ class Colormap(resource.Resource):
                                   blue = blue)
 
     def alloc_named_color(self, name):
+        # type: (str) -> request.AllocColor | request.AllocNamedColor | None
         for r in rgb_res:
             m = r.match(name)
             if m:
@@ -93,6 +110,7 @@ class Colormap(resource.Resource):
             return None
 
     def alloc_color_cells(self, contiguous, colors, planes):
+        # type: (bool, int, int) -> request.AllocColorCells
         return request.AllocColorCells(display = self.display,
                                        contiguous = contiguous,
                                        cmap = self.id,
@@ -100,6 +118,7 @@ class Colormap(resource.Resource):
                                        planes = planes)
 
     def alloc_color_planes(self, contiguous, colors, red, green, blue):
+        # type: (bool, int, int, int, int) -> request.AllocColorPlanes
         return request.AllocColorPlanes(display = self.display,
                                         contiguous = contiguous,
                                         cmap = self.id,
@@ -109,6 +128,7 @@ class Colormap(resource.Resource):
                                         blue = blue)
 
     def free_colors(self, pixels, plane_mask, onerror = None):
+        # type: (Sequence[int], int, _ErrorHandler[object] | None) -> None
         request.FreeColors(display = self.display,
                            onerror = onerror,
                            cmap = self.id,
@@ -116,12 +136,14 @@ class Colormap(resource.Resource):
                            pixels = pixels)
 
     def store_colors(self, items, onerror = None):
+        # type: (dict[str, int], _ErrorHandler[object] | None) -> None
         request.StoreColors(display = self.display,
                             onerror = onerror,
                             cmap = self.id,
                             items = items)
 
     def store_named_color(self, name, pixel, flags, onerror = None):
+        # type: (str, int, int, _ErrorHandler[object] | None) -> None
         request.StoreNamedColor(display = self.display,
                                 onerror = onerror,
                                 flags = flags,
@@ -130,12 +152,14 @@ class Colormap(resource.Resource):
                                 name = name)
 
     def query_colors(self, pixels):
+        # type: (Sequence[int]) -> rq.Struct
         r = request.QueryColors(display = self.display,
                                 cmap = self.id,
                                 pixels = pixels)
         return r.colors
 
     def lookup_color(self, name):
+        # type: (str) -> request.LookupColor
         return request.LookupColor(display = self.display,
                                    cmap = self.id,
                                    name = name)

--- a/Xlib/xobject/cursor.py
+++ b/Xlib/xobject/cursor.py
@@ -23,16 +23,30 @@ from Xlib.protocol import request
 
 from . import resource
 
+try:
+    from typing import TYPE_CHECKING, TypeVar, Optional
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import TypeAlias
+    from Xlib.error import XError
+    from Xlib.protocol.rq import Request
+    _T = TypeVar("_T")
+    _ErrorHandler:  TypeAlias = Callable[[XError, Optional[Request]], _T]
+
 class Cursor(resource.Resource):
     __cursor__ = resource.Resource.__resource__
 
     def free(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.FreeCursor(display = self.display,
                            onerror = onerror,
                            cursor = self.id)
         self.display.free_resource_id(self.id)
 
     def recolor(self, foreground, background, onerror=None):
+        # type: (tuple[int, int, int], tuple[int, int, int],  _ErrorHandler[object] | None) -> None
         fore_red, fore_green, fore_blue = foreground
         back_red, back_green, back_blue = background
 

--- a/Xlib/xobject/drawable.py
+++ b/Xlib/xobject/drawable.py
@@ -31,6 +31,21 @@ from . import fontable
 # Inter-client communication conventions
 from . import icccm
 
+try:
+    from typing import TYPE_CHECKING, TypeVar, Optional, Union, Any
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence, Iterable
+    from typing_extensions import TypeAlias
+    from Xlib.error import XError
+    from PIL import Image
+    from array import array
+    from mmap import mmap
+    _T = TypeVar("_T")
+    _SliceableBuffer: TypeAlias = Union[bytes, bytearray, memoryview, array[Any], mmap]
+    _ErrorHandler:  TypeAlias = Callable[[XError, Optional[rq.Request]], _T]
+
 class Drawable(resource.Resource):
     __drawable__ = resource.Resource.__resource__
 
@@ -39,6 +54,7 @@ class Drawable(resource.Resource):
                                    drawable = self)
 
     def create_pixmap(self, width, height, depth):
+        # type: (int, int, int) -> Pixmap
         pid = self.display.allocate_resource_id()
         request.CreatePixmap(display = self.display,
                              depth = depth,
@@ -51,6 +67,7 @@ class Drawable(resource.Resource):
         return cls(self.display, pid, owner = 1)
 
     def create_gc(self, **keys):
+        # type: (object) -> fontable.GC
         cid = self.display.allocate_resource_id()
         request.CreateGC(display = self.display,
                          cid = cid,
@@ -61,6 +78,7 @@ class Drawable(resource.Resource):
         return cls(self.display, cid, owner = 1)
 
     def copy_area(self, gc, src_drawable, src_x, src_y, width, height, dst_x, dst_y, onerror = None):
+        # type: (int, int, int, int, int, int, int, int, _ErrorHandler[object] | None) -> None
         request.CopyArea(display = self.display,
                          onerror = onerror,
                          src_drawable = src_drawable,
@@ -75,6 +93,7 @@ class Drawable(resource.Resource):
 
     def copy_plane(self, gc, src_drawable, src_x, src_y, width, height,
                    dst_x, dst_y, bit_plane, onerror = None):
+        # type: (int, int, int, int, int, int, int, int, int, _ErrorHandler[object] | None) -> None
         request.CopyPlane(display = self.display,
                           onerror = onerror,
                           src_drawable = src_drawable,
@@ -89,6 +108,7 @@ class Drawable(resource.Resource):
                           bit_plane = bit_plane)
 
     def poly_point(self, gc, coord_mode, points, onerror = None):
+        # type: (int, int, Sequence[tuple[int, int]], _ErrorHandler[object] | None) -> None
         request.PolyPoint(display = self.display,
                           onerror = onerror,
                           coord_mode = coord_mode,
@@ -97,6 +117,7 @@ class Drawable(resource.Resource):
                           points = points)
 
     def point(self, gc, x, y, onerror = None):
+        # type: (int, int, int, _ErrorHandler[object] | None) -> None
         request.PolyPoint(display = self.display,
                           onerror = onerror,
                           coord_mode = X.CoordModeOrigin,
@@ -105,6 +126,7 @@ class Drawable(resource.Resource):
                           points = [(x, y)])
 
     def poly_line(self, gc, coord_mode, points, onerror = None):
+        # type: (int, int, Sequence[tuple[int, int]], _ErrorHandler[object] | None) -> None
         request.PolyLine(display = self.display,
                          onerror = onerror,
                          coord_mode = coord_mode,
@@ -113,6 +135,7 @@ class Drawable(resource.Resource):
                          points = points)
 
     def line(self, gc, x1, y1, x2, y2, onerror = None):
+        # type: (int, int, int, int, int, _ErrorHandler[object] | None) -> None
         request.PolySegment(display = self.display,
                             onerror = onerror,
                             drawable = self.id,
@@ -120,6 +143,7 @@ class Drawable(resource.Resource):
                             segments = [(x1, y1, x2, y2)])
 
     def poly_segment(self, gc, segments, onerror = None):
+        # type: (int, Sequence[tuple[int, int, int, int]], _ErrorHandler[object] | None) -> None
         request.PolySegment(display = self.display,
                             onerror = onerror,
                             drawable = self.id,
@@ -127,6 +151,7 @@ class Drawable(resource.Resource):
                             segments = segments)
 
     def poly_rectangle(self, gc, rectangles, onerror = None):
+        # type: (int, Sequence[tuple[int, int, int, int]], _ErrorHandler[object] | None) -> None
         request.PolyRectangle(display = self.display,
                               onerror = onerror,
                               drawable = self.id,
@@ -134,6 +159,7 @@ class Drawable(resource.Resource):
                               rectangles = rectangles)
 
     def rectangle(self, gc, x, y, width, height, onerror = None):
+        # type: (int, int, int, int, int,  _ErrorHandler[object] | None) -> None
         request.PolyRectangle(display = self.display,
                               onerror = onerror,
                               drawable = self.id,
@@ -142,6 +168,7 @@ class Drawable(resource.Resource):
 
 
     def poly_arc(self, gc, arcs, onerror = None):
+        # type: (int, Sequence[tuple[int, int, int, int, int, int]], _ErrorHandler[object] | None) -> None
         request.PolyArc(display = self.display,
                         onerror = onerror,
                         drawable = self.id,
@@ -149,6 +176,7 @@ class Drawable(resource.Resource):
                         arcs = arcs)
 
     def arc(self, gc,  x, y, width, height, angle1, angle2, onerror = None):
+        # type: (int, int, int, int, int, int, int, _ErrorHandler[object] | None) -> None
         request.PolyArc(display = self.display,
                         onerror = onerror,
                         drawable = self.id,
@@ -156,6 +184,7 @@ class Drawable(resource.Resource):
                         arcs = [(x, y, width, height, angle1, angle2)])
 
     def fill_poly(self, gc, shape, coord_mode, points, onerror = None):
+        # type: (int, int, int, Sequence[tuple[int, int]], _ErrorHandler[object] | None) -> None
         request.FillPoly(display = self.display,
                          onerror = onerror,
                          shape = shape,
@@ -165,6 +194,7 @@ class Drawable(resource.Resource):
                          points = points)
 
     def poly_fill_rectangle(self, gc, rectangles, onerror = None):
+        # type: (int, Sequence[tuple[int, int, int, int]], _ErrorHandler[object] | None) -> None
         request.PolyFillRectangle(display = self.display,
                                   onerror = onerror,
                                   drawable = self.id,
@@ -172,6 +202,7 @@ class Drawable(resource.Resource):
                                   rectangles = rectangles)
 
     def fill_rectangle(self, gc, x, y, width, height, onerror = None):
+        # type: (int, int, int, int, int, _ErrorHandler[object] | None) -> None
         request.PolyFillRectangle(display = self.display,
                                   onerror = onerror,
                                   drawable = self.id,
@@ -179,6 +210,7 @@ class Drawable(resource.Resource):
                                   rectangles = [(x, y, width, height)])
 
     def poly_fill_arc(self, gc, arcs, onerror = None):
+        # type: (int, Sequence[tuple[int, int, int, int, int, int]], _ErrorHandler[object] | None) -> None
         request.PolyFillArc(display = self.display,
                             onerror = onerror,
                             drawable = self.id,
@@ -186,6 +218,7 @@ class Drawable(resource.Resource):
                             arcs = arcs)
 
     def fill_arc(self, gc,  x, y, width, height, angle1, angle2, onerror = None):
+        # type: (int, int, int, int, int, int, int, _ErrorHandler[object] | None) -> None
         request.PolyFillArc(display = self.display,
                             onerror = onerror,
                             drawable = self.id,
@@ -195,6 +228,7 @@ class Drawable(resource.Resource):
 
     def put_image(self, gc, x, y, width, height, format,
                   depth, left_pad, data, onerror = None):
+        # type: (int, int, int, int, int, int, int, int, _SliceableBuffer, _ErrorHandler[object] | None) -> None
         request.PutImage(display = self.display,
                          onerror = onerror,
                          format = format,
@@ -211,6 +245,7 @@ class Drawable(resource.Resource):
     # Trivial little method for putting PIL images.  Will break on anything
     # but depth 1 or 24...
     def put_pil_image(self, gc, x, y, image, onerror = None):
+        # type: (int, int, int, Image.Image, _ErrorHandler[object] | None) -> None
         width, height = image.size
         if image.mode == '1':
             format = X.XYBitmap
@@ -256,6 +291,7 @@ class Drawable(resource.Resource):
 
 
     def get_image(self, x, y, width, height, format, plane_mask):
+        # type: (int, int, int, int, int, int) -> request.GetImage
         return request.GetImage(display = self.display,
                                 format = format,
                                 drawable = self.id,
@@ -266,6 +302,7 @@ class Drawable(resource.Resource):
                                 plane_mask = plane_mask)
 
     def draw_text(self, gc, x, y, text, onerror = None):
+        # type: (int, int, int, dict[str, str | int], _ErrorHandler[object] | None) -> None
         request.PolyText8(display = self.display,
                           onerror = onerror,
                           drawable = self.id,
@@ -275,6 +312,7 @@ class Drawable(resource.Resource):
                           items = [text])
 
     def poly_text(self, gc, x, y, items, onerror = None):
+        # type: (int, int, int, Sequence[dict[str, str | int]], _ErrorHandler[object] | None) -> None
         request.PolyText8(display = self.display,
                           onerror = onerror,
                           drawable = self.id,
@@ -284,6 +322,7 @@ class Drawable(resource.Resource):
                           items = items)
 
     def poly_text_16(self, gc, x, y, items, onerror = None):
+        # type: (int, int, int, Sequence[dict[str, str | int]], _ErrorHandler[object] | None) -> None
         request.PolyText16(display = self.display,
                            onerror = onerror,
                            drawable = self.id,
@@ -293,6 +332,7 @@ class Drawable(resource.Resource):
                            items = items)
 
     def image_text(self, gc, x, y, string, onerror = None):
+        # type: (int, int, int, str, _ErrorHandler[object] | None) -> None
         request.ImageText8(display = self.display,
                            onerror = onerror,
                            drawable = self.id,
@@ -302,6 +342,7 @@ class Drawable(resource.Resource):
                            string = string)
 
     def image_text_16(self, gc, x, y, string, onerror = None):
+        # type: (int, int, int, str, _ErrorHandler[object] | None) -> None
         request.ImageText16(display = self.display,
                             onerror = onerror,
                             drawable = self.id,
@@ -311,6 +352,7 @@ class Drawable(resource.Resource):
                             string = string)
 
     def query_best_size(self, item_class, width, height):
+        # type: (int, int, int) -> request.QueryBestSize
         return request.QueryBestSize(display = self.display,
                                      item_class = item_class,
                                      drawable = self.id,
@@ -328,6 +370,7 @@ class Window(Drawable):
                       visual = X.CopyFromParent,
                       onerror = None,
                       **keys):
+        # type: (int, int, int, int, int, int, int, int, _ErrorHandler[object] | None, object) -> Window
 
         wid = self.display.allocate_resource_id()
         request.CreateWindow(display = self.display,
@@ -348,6 +391,7 @@ class Window(Drawable):
         return cls(self.display, wid, owner = 1)
 
     def change_attributes(self, onerror = None, **keys):
+        # type: (_ErrorHandler[object] | None, object) -> None
         request.ChangeWindowAttributes(display = self.display,
                                        onerror = onerror,
                                        window = self.id,
@@ -358,6 +402,7 @@ class Window(Drawable):
                                            window = self.id)
 
     def destroy(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.DestroyWindow(display = self.display,
                               onerror = onerror,
                               window = self.id)
@@ -365,18 +410,21 @@ class Window(Drawable):
         self.display.free_resource_id(self.id)
 
     def destroy_sub_windows(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.DestroySubWindows(display = self.display,
                                   onerror = onerror,
                                   window = self.id)
 
 
     def change_save_set(self, mode, onerror = None):
+        # type: (int, _ErrorHandler[object] | None) -> None
         request.ChangeSaveSet(display = self.display,
                               onerror = onerror,
                               mode = mode,
                               window = self.id)
 
     def reparent(self, parent, x, y, onerror = None):
+        # type: (int, int, int, _ErrorHandler[object] | None) -> None
         request.ReparentWindow(display = self.display,
                                onerror = onerror,
                                window = self.id,
@@ -385,38 +433,45 @@ class Window(Drawable):
                                y = y)
 
     def map(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.MapWindow(display = self.display,
                           onerror = onerror,
                           window = self.id)
 
     def map_sub_windows(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.MapSubwindows(display = self.display,
                               onerror = onerror,
                               window = self.id)
 
     def unmap(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.UnmapWindow(display = self.display,
                             onerror = onerror,
                             window = self.id)
 
     def unmap_sub_windows(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.UnmapSubwindows(display = self.display,
                                 onerror = onerror,
                                 window = self.id)
 
     def configure(self, onerror = None, **keys):
+        # type: (_ErrorHandler[object] | None, object) -> None
         request.ConfigureWindow(display = self.display,
                                 onerror = onerror,
                                 window = self.id,
                                 attrs = keys)
 
     def circulate(self, direction, onerror = None):
+        # type: (int, _ErrorHandler[object] | None) -> None
         request.CirculateWindow(display = self.display,
                                 onerror = onerror,
                                 direction = direction,
                                 window = self.id)
 
     def raise_window(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         """alias for raising the window to the top - as in XRaiseWindow"""
         self.configure(onerror, stack_mode = X.Above)
 
@@ -426,6 +481,7 @@ class Window(Drawable):
 
     def change_property(self, property, property_type, format, data,
                         mode = X.PropModeReplace, onerror = None):
+        # type: (int, int, int, Sequence[float] | Sequence[str], int, _ErrorHandler[object] | None) -> None
 
         request.ChangeProperty(display = self.display,
                                onerror = onerror,
@@ -437,6 +493,7 @@ class Window(Drawable):
 
     def change_text_property(self, property, property_type, data,
                         mode = X.PropModeReplace, onerror = None):
+        # type: (int, int, bytes | str, int, _ErrorHandler[object] | None) -> None
         if not isinstance(data, bytes):
             if property_type == Xatom.STRING:
                 data = data.encode(self._STRING_ENCODING)
@@ -446,12 +503,14 @@ class Window(Drawable):
                              mode=mode, onerror=onerror)
 
     def delete_property(self, property, onerror = None):
+        # type: (int, _ErrorHandler[object] | None) -> None
         request.DeleteProperty(display = self.display,
                                onerror = onerror,
                                window = self.id,
                                property = property)
 
     def get_property(self, property, property_type, offset, length, delete = 0):
+        # type: (int, int, int, int, bool) -> request.GetProperty | None
         r = request.GetProperty(display = self.display,
                                 delete = delete,
                                 window = self.id,
@@ -469,6 +528,7 @@ class Window(Drawable):
             return None
 
     def get_full_property(self, property, property_type, sizehint = 10):
+        # type: (int, int, int) -> request.GetProperty | None
         prop = self.get_property(property, property_type, 0, sizehint)
         if prop:
             val = prop.value
@@ -483,6 +543,7 @@ class Window(Drawable):
             return None
 
     def get_full_text_property(self, property, property_type=X.AnyPropertyType, sizehint = 10):
+        # type: (int, int, int) -> str | None
         prop = self.get_full_property(property, property_type,
                                       sizehint=sizehint)
         if prop is None or prop.format != 8:
@@ -496,11 +557,13 @@ class Window(Drawable):
         return prop.value
 
     def list_properties(self):
+        # type: () -> list[int]
         r = request.ListProperties(display = self.display,
                                    window = self.id)
         return r.atoms
 
     def set_selection_owner(self, selection, time, onerror = None):
+        # type: (int, int, _ErrorHandler[object] | None) -> None
         request.SetSelectionOwner(display = self.display,
                                   onerror = onerror,
                                   window = self.id,
@@ -508,6 +571,7 @@ class Window(Drawable):
                                   time = time)
 
     def convert_selection(self, selection, target, property, time, onerror = None):
+        # type: (int, int, int, int, _ErrorHandler[object] | None) -> None
         request.ConvertSelection(display = self.display,
                                  onerror = onerror,
                                  requestor = self.id,
@@ -517,6 +581,7 @@ class Window(Drawable):
                                  time = time)
 
     def send_event(self, event, event_mask = 0, propagate = 0, onerror = None):
+        # type: (rq.Event, int, bool, _ErrorHandler[object] | None) -> None
         request.SendEvent(display = self.display,
                           onerror = onerror,
                           propagate = propagate,
@@ -527,6 +592,7 @@ class Window(Drawable):
     def grab_pointer(self, owner_events, event_mask,
                      pointer_mode, keyboard_mode,
                      confine_to, cursor, time):
+        # type: (bool, int, int, int, int, int, int) -> None
 
         r = request.GrabPointer(display = self.display,
                                 owner_events = owner_events,
@@ -542,6 +608,7 @@ class Window(Drawable):
     def grab_button(self, button, modifiers, owner_events, event_mask,
                     pointer_mode, keyboard_mode,
                     confine_to, cursor, onerror = None):
+        # type: (int, int, bool, int, int, int, int, int, _ErrorHandler[object] | None) -> None
 
         request.GrabButton(display = self.display,
                            onerror = onerror,
@@ -556,6 +623,7 @@ class Window(Drawable):
                            modifiers = modifiers)
 
     def ungrab_button(self, button, modifiers, onerror = None):
+        # type: (int, int, _ErrorHandler[object] | None) -> None
         request.UngrabButton(display = self.display,
                              onerror = onerror,
                              button = button,
@@ -564,6 +632,7 @@ class Window(Drawable):
 
 
     def grab_keyboard(self, owner_events, pointer_mode, keyboard_mode, time):
+        # type: (bool, int, int, int) -> int
         r = request.GrabKeyboard(display = self.display,
                                  owner_events = owner_events,
                                  grab_window = self.id,
@@ -574,6 +643,7 @@ class Window(Drawable):
         return r.status
 
     def grab_key(self, key, modifiers, owner_events, pointer_mode, keyboard_mode, onerror = None):
+        # type: (int, int, bool, int, int, _ErrorHandler[object] | None) -> None
         request.GrabKey(display = self.display,
                         onerror = onerror,
                         owner_events = owner_events,
@@ -584,6 +654,7 @@ class Window(Drawable):
                         keyboard_mode = keyboard_mode)
 
     def ungrab_key(self, key, modifiers, onerror = None):
+        # type: (int, int, _ErrorHandler[object] | None) -> None
         request.UngrabKey(display = self.display,
                           onerror = onerror,
                           key = key,
@@ -595,6 +666,7 @@ class Window(Drawable):
                                     window = self.id)
 
     def get_motion_events(self, start, stop):
+        # type: (int, int) -> rq.Struct
         r = request.GetMotionEvents(display = self.display,
                                     window = self.id,
                                     start = start,
@@ -602,6 +674,7 @@ class Window(Drawable):
         return r.events
 
     def translate_coords(self, src_window, src_x, src_y):
+        # type: (int, int, int) -> request.TranslateCoords
         return request.TranslateCoords(display = self.display,
                                        src_wid = src_window,
                                        dst_wid = self.id,
@@ -610,6 +683,7 @@ class Window(Drawable):
 
     def warp_pointer(self, x, y, src_window = 0, src_x = 0, src_y = 0,
                      src_width = 0, src_height = 0, onerror = None):
+        # type: (int, int, int, int, int, int, int, _ErrorHandler[object] | None) -> None
 
         request.WarpPointer(display = self.display,
                             onerror = onerror,
@@ -623,6 +697,7 @@ class Window(Drawable):
                             dst_y = y)
 
     def set_input_focus(self, revert_to, time, onerror = None):
+        # type: (int, int, _ErrorHandler[object] | None) -> None
         request.SetInputFocus(display = self.display,
                               onerror = onerror,
                               revert_to = revert_to,
@@ -630,6 +705,7 @@ class Window(Drawable):
                               time = time)
 
     def clear_area(self, x = 0, y = 0, width = 0, height = 0, exposures = 0, onerror = None):
+        # type: (int, int, int, int, bool, _ErrorHandler[object] | None) -> None
         request.ClearArea(display = self.display,
                           onerror = onerror,
                           exposures = exposures,
@@ -640,6 +716,7 @@ class Window(Drawable):
                           height = height)
 
     def create_colormap(self, visual, alloc):
+        # type: (int, int) -> colormap.Colormap
         mid = self.display.allocate_resource_id()
         request.CreateColormap(display = self.display,
                                alloc = alloc,
@@ -650,11 +727,13 @@ class Window(Drawable):
         return cls(self.display, mid, owner = 1)
 
     def list_installed_colormaps(self):
+        # type: () -> list[colormap.Colormap]
         r = request.ListInstalledColormaps(display = self.display,
                                            window = self.id)
         return r.cmaps
 
     def rotate_properties(self, properties, delta, onerror = None):
+        # type: (Sequence[int], int, _ErrorHandler[object] | None) -> None
         request.RotateProperties(display = self.display,
                                  onerror = onerror,
                                  window = self.id,
@@ -662,6 +741,7 @@ class Window(Drawable):
                                  properties = properties)
 
     def set_wm_name(self, name, onerror = None):
+        # type: (bytes | str, _ErrorHandler[object] | None) -> None
         self.change_text_property(Xatom.WM_NAME, Xatom.STRING, name,
                                   onerror = onerror)
 
@@ -669,6 +749,7 @@ class Window(Drawable):
         return self.get_full_text_property(Xatom.WM_NAME, Xatom.STRING)
 
     def set_wm_icon_name(self, name, onerror = None):
+        # type: (bytes | str, _ErrorHandler[object] | None) -> None
         self.change_text_property(Xatom.WM_ICON_NAME, Xatom.STRING, name,
                                   onerror = onerror)
 
@@ -676,6 +757,7 @@ class Window(Drawable):
         return self.get_full_text_property(Xatom.WM_ICON_NAME, Xatom.STRING)
 
     def set_wm_class(self, inst, cls, onerror = None):
+        # type: (str, str, _ErrorHandler[object] | None) -> None
         self.change_text_property(Xatom.WM_CLASS, Xatom.STRING,
                                   '%s\0%s\0' % (inst, cls),
                                   onerror = onerror)
@@ -691,6 +773,7 @@ class Window(Drawable):
             return parts[0], parts[1]
 
     def set_wm_transient_for(self, window, onerror = None):
+        # type: (Window, _ErrorHandler[object] | None) -> None
         self.change_property(Xatom.WM_TRANSIENT_FOR, Xatom.WINDOW,
                              32, [window.id],
                              onerror = onerror)
@@ -705,11 +788,13 @@ class Window(Drawable):
 
 
     def set_wm_protocols(self, protocols, onerror = None):
+        # type: (Iterable[int], _ErrorHandler[object] | None) -> None
         self.change_property(self.display.get_atom('WM_PROTOCOLS'),
                              Xatom.ATOM, 32, protocols,
                              onerror = onerror)
 
     def get_wm_protocols(self):
+        # type: () -> list[int]
         d = self.get_full_property(self.display.get_atom('WM_PROTOCOLS'), Xatom.ATOM)
         if d is None or d.format != 32:
             return []
@@ -717,12 +802,14 @@ class Window(Drawable):
             return d.value
 
     def set_wm_colormap_windows(self, windows, onerror = None):
+        # type: (Iterable[Window], _ErrorHandler[object] | None) -> None
         self.change_property(self.display.get_atom('WM_COLORMAP_WINDOWS'),
                              Xatom.WINDOW, 32,
                              map(lambda w: w.id, windows),
                              onerror = onerror)
 
     def get_wm_colormap_windows(self):
+        # type: () -> list[Window] | map[Window]
         d = self.get_full_property(self.display.get_atom('WM_COLORMAP_WINDOWS'),
                                    Xatom.WINDOW)
         if d is None or d.format != 32:
@@ -734,6 +821,7 @@ class Window(Drawable):
 
 
     def set_wm_client_machine(self, name, onerror = None):
+        # type: (bytes | str, _ErrorHandler[object] | None) -> None
         self.change_text_property(Xatom.WM_CLIENT_MACHINE, Xatom.STRING, name,
                                   onerror = onerror)
 
@@ -741,6 +829,7 @@ class Window(Drawable):
         return self.get_full_text_property(Xatom.WM_CLIENT_MACHINE, Xatom.STRING)
 
     def set_wm_normal_hints(self, hints = {}, onerror = None, **keys):
+        # type: (rq.DictWrapper | dict[str, object], _ErrorHandler[object] | None, object) -> None
         self._set_struct_prop(Xatom.WM_NORMAL_HINTS, Xatom.WM_SIZE_HINTS,
                               icccm.WMNormalHints, hints, keys, onerror)
 
@@ -749,6 +838,7 @@ class Window(Drawable):
                                      icccm.WMNormalHints)
 
     def set_wm_hints(self, hints = {}, onerror = None, **keys):
+        # type: (rq.DictWrapper | dict[str, object], _ErrorHandler[object] | None, object) -> None
         self._set_struct_prop(Xatom.WM_HINTS, Xatom.WM_HINTS,
                               icccm.WMHints, hints, keys, onerror)
 
@@ -757,6 +847,7 @@ class Window(Drawable):
                                      icccm.WMHints)
 
     def set_wm_state(self, hints = {}, onerror = None, **keys):
+        # type: (rq.DictWrapper | dict[str, object], _ErrorHandler[object] | None, object) -> None
         atom = self.display.get_atom('WM_STATE')
         self._set_struct_prop(atom, atom, icccm.WMState, hints, keys, onerror)
 
@@ -765,6 +856,7 @@ class Window(Drawable):
         return self._get_struct_prop(atom, atom, icccm.WMState)
 
     def set_wm_icon_size(self, hints = {}, onerror = None, **keys):
+        # type: (rq.DictWrapper | dict[str, object], _ErrorHandler[object] | None, object) -> None
         self._set_struct_prop(Xatom.WM_ICON_SIZE, Xatom.WM_ICON_SIZE,
                               icccm.WMIconSize, hints, keys, onerror)
 
@@ -777,6 +869,7 @@ class Window(Drawable):
     # Returns a DictWrapper, or None
 
     def _get_struct_prop(self, pname, ptype, pstruct):
+        # type: (int, int, rq.Struct) -> rq.DictWrapper | None
         r = self.get_property(pname, ptype, 0, pstruct.static_size // 4)
         if r and r.format == 32:
             value = rq.encode_array(r.value)
@@ -791,6 +884,7 @@ class Window(Drawable):
     # will be modified.  onerror is the error handler.
 
     def _set_struct_prop(self, pname, ptype, pstruct, hints, keys, onerror):
+        # type: (int, int, rq.Struct, rq.DictWrapper | dict[str, object], dict[str, object], _ErrorHandler[object] | None) -> None
         if isinstance(hints, rq.DictWrapper):
             keys.update(hints._data)
         else:
@@ -805,6 +899,7 @@ class Pixmap(Drawable):
     __pixmap__ = resource.Resource.__resource__
 
     def free(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.FreePixmap(display = self.display,
                            onerror = onerror,
                            pixmap = self.id)
@@ -812,6 +907,7 @@ class Pixmap(Drawable):
         self.display.free_resource_id(self.id)
 
     def create_cursor(self, mask, foreground, background, x, y):
+        # type: (int, tuple[int, int, int], tuple[int, int, int], int, int) -> cursor.Cursor
         fore_red, fore_green, fore_blue = foreground
         back_red, back_green, back_blue = background
         cid = self.display.allocate_resource_id()
@@ -832,4 +928,5 @@ class Pixmap(Drawable):
 
 
 def roundup(value, unit):
+    # type: (int, int) -> int
     return (value + (unit - 1)) & ~(unit - 1)

--- a/Xlib/xobject/fontable.py
+++ b/Xlib/xobject/fontable.py
@@ -24,6 +24,19 @@ from Xlib.protocol import request
 from . import resource
 from . import cursor
 
+try:
+    from typing import TYPE_CHECKING, TypeVar, Optional
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import TypeAlias
+    from Xlib.error import XError
+    from Xlib.protocol.rq import Request
+    from collections.abc import Sequence
+    _T = TypeVar("_T")
+    _ErrorHandler:  TypeAlias = Callable[[XError, Optional[Request]], _T]
+
 class Fontable(resource.Resource):
     __fontable__ = resource.Resource.__resource__
 
@@ -32,6 +45,7 @@ class Fontable(resource.Resource):
                                  font = self.id)
 
     def query_text_extents(self, string):
+        # type: (str) -> request.QueryTextExtents
         return request.QueryTextExtents(display = self.display,
                                         font = self.id,
                                         string = string)
@@ -41,6 +55,7 @@ class GC(Fontable):
     __gc__ = resource.Resource.__resource__
 
     def change(self, onerror = None, **keys):
+        # type: (_ErrorHandler[object] | None, object) -> None
         request.ChangeGC(display = self.display,
                          onerror = onerror,
                          gc = self.id,
@@ -48,6 +63,7 @@ class GC(Fontable):
 
 
     def copy(self, src_gc, mask, onerror = None):
+        # type: (int, int, _ErrorHandler[object] | None) -> None
         request.CopyGC(display = self.display,
                        onerror = onerror,
                        src_gc = src_gc,
@@ -55,6 +71,7 @@ class GC(Fontable):
                        mask = mask)
 
     def set_dashes(self, offset, dashes, onerror = None):
+        # type: (int, Sequence[int], _ErrorHandler[object] | None) -> None
         request.SetDashes(display = self.display,
                           onerror = onerror,
                           gc = self.id,
@@ -62,6 +79,7 @@ class GC(Fontable):
                           dashes = dashes)
 
     def set_clip_rectangles(self, x_origin, y_origin, rectangles, ordering, onerror = None):
+        # type: (int, int, Sequence[Sequence[int] | tuple[int, int, int, int]], Sequence[int] | tuple[int, int, int, int], _ErrorHandler[object] | None) -> None
         request.SetClipRectangles(display = self.display,
                                   onerror = onerror,
                                   ordering = ordering,
@@ -70,6 +88,7 @@ class GC(Fontable):
                                   y_origin = y_origin,
                                   rectangles = rectangles)
     def free(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.FreeGC(display = self.display,
                        onerror = onerror,
                        gc = self.id)
@@ -82,6 +101,7 @@ class Font(Fontable):
     __font__ = resource.Resource.__resource__
 
     def close(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.CloseFont(display = self.display,
                           onerror = onerror,
                           font = self.id)
@@ -89,6 +109,7 @@ class Font(Fontable):
 
     def create_glyph_cursor(self, mask, source_char, mask_char,
                             foreground, background):
+        # type: (Font, int, int, tuple[int, int, int], tuple[int, int, int]) -> cursor.Cursor
         fore_red, fore_green, fore_blue = foreground
         back_red, back_green, back_blue = background
 

--- a/Xlib/xobject/resource.py
+++ b/Xlib/xobject/resource.py
@@ -21,8 +21,22 @@
 
 from Xlib.protocol import request
 
+try:
+    from typing import TYPE_CHECKING, TypeVar, Optional
+except ImportError:
+    TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import TypeAlias
+    from Xlib.error import XError
+    from Xlib.protocol.rq import Request
+    from Xlib.display import _BaseDisplay
+    _T = TypeVar("_T")
+    _ErrorHandler:  TypeAlias = Callable[[XError, Optional[Request]], _T]
+
 class Resource(object):
     def __init__(self, display, rid, owner = 0):
+        # type: (_BaseDisplay, int, int) -> None
         self.display = display
         self.id = rid
         self.owner = owner
@@ -31,6 +45,7 @@ class Resource(object):
         return self.id
 
     def __eq__(self, obj):
+        # type: (object) -> bool
         if isinstance(obj, Resource):
             if self.display == obj.display:
                 return self.id == obj.id
@@ -40,6 +55,7 @@ class Resource(object):
             return id(self) == id(obj)
 
     def __ne__(self, obj):
+        # type: (object) -> bool
         return not self == obj
 
     def __hash__(self):
@@ -49,6 +65,7 @@ class Resource(object):
         return '<%s 0x%08x>' % (self.__class__.__name__, self.id)
 
     def kill_client(self, onerror = None):
+        # type: (_ErrorHandler[object] | None) -> None
         request.KillClient(display = self.display,
                            onerror = onerror,
                            resource = self.id)

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,5 @@ setup(
         'Xlib.support',
         'Xlib.xobject'
     ],
+    package_data={"Xlib": ["Xlib/py.typed"]},
 )


### PR DESCRIPTION
Added type comments as per PEP 561 to type all public API while staying Python 2 compatible. (type definitions only need to be compatible with non EOL python versions. Using type comments instead of inline-types allows the code to still run on Python 2)

Added a `py.typed` marker to let type checkers know that this package provides its own types. And to not look for external type-stubs.

Some dynamic types (like `Struct`, `Request`, `Event`, ...) are naturally incomplete, but this was more than enough for my needs. And would add a lot of complexity to support.