### PR TITLE
build: Migrate from pkg_resources to importlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 # Distutils script for python-xlib
 
-from pkg_resources import parse_requirements
+from importlib.metadata import version
 from setuptools import (__version__ as setuptools_version, setup)
 
 
 # Check setuptools is recent enough to support `setup.cfg`.
-setuptools_require = next(parse_requirements('setuptools>=30.3.0'))
-assert setuptools_version in setuptools_require, '{} is required'.format(setuptools_require)
+installed_version = version('setuptools')
+setuptools_require = '30.3.0'
+assert setuptools_version >= setuptools_require, 'setuptools >= {} is required'.format(setuptools_require)
 
 
 setup(


### PR DESCRIPTION
Setuptools 82 removed the `pkg_resources` module. The replacement is mostly `importlib`, with some other modules. This fixes the use of the removed module.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
